### PR TITLE
[#84] Updated genai.TextPart

### DIFF
--- a/bedrock/bedrock_test.go
+++ b/bedrock/bedrock_test.go
@@ -486,8 +486,8 @@ func TestToGenResponse(t *testing.T) {
 	if len(genResp.Candidates[0].Message.Parts) != 1 {
 		t.Fatalf("Parts length = %d, want 1", len(genResp.Candidates[0].Message.Parts))
 	}
-	if genResp.Candidates[0].Message.Parts[0].Text.Text != "Hello! How can I help?" {
-		t.Errorf("text = %q, want %q", genResp.Candidates[0].Message.Parts[0].Text.Text, "Hello! How can I help?")
+	if genResp.Candidates[0].Message.Parts[0].Text.Content != "Hello! How can I help?" {
+		t.Errorf("text = %q, want %q", genResp.Candidates[0].Message.Parts[0].Text.Content, "Hello! How can I help?")
 	}
 }
 
@@ -554,8 +554,8 @@ func TestStreamEventToGenResponse_TextDelta(t *testing.T) {
 	if genResp.Candidates[0].FinishReason != genai.FinishReasonInProgress {
 		t.Errorf("FinishReason = %v, want null (in progress)", genResp.Candidates[0].FinishReason)
 	}
-	if genResp.Candidates[0].Message.Parts[0].Text.Text != "Hello" {
-		t.Errorf("text = %q, want %q", genResp.Candidates[0].Message.Parts[0].Text.Text, "Hello")
+	if genResp.Candidates[0].Message.Parts[0].Text.Content != "Hello" {
+		t.Errorf("text = %q, want %q", genResp.Candidates[0].Message.Parts[0].Text.Content, "Hello")
 	}
 }
 
@@ -747,8 +747,8 @@ func TestGenerate_Success(t *testing.T) {
 	if len(resp.Candidates) != 1 {
 		t.Fatalf("Candidates length = %d, want 1", len(resp.Candidates))
 	}
-	if resp.Candidates[0].Message.Parts[0].Text.Text != "Go is a programming language." {
-		t.Errorf("text = %q, want %q", resp.Candidates[0].Message.Parts[0].Text.Text, "Go is a programming language.")
+	if resp.Candidates[0].Message.Parts[0].Text.Content != "Go is a programming language." {
+		t.Errorf("text = %q, want %q", resp.Candidates[0].Message.Parts[0].Text.Content, "Go is a programming language.")
 	}
 	if resp.Meta.InputTokens != 10 {
 		t.Errorf("InputTokens = %d, want 10", resp.Meta.InputTokens)
@@ -826,7 +826,7 @@ func TestBedrockMessageToGenMessage_Text(t *testing.T) {
 	if len(genMsg.Parts) != 1 {
 		t.Fatalf("Parts length = %d, want 1", len(genMsg.Parts))
 	}
-	if genMsg.Parts[0].Text == nil || genMsg.Parts[0].Text.Text != "Hello!" {
+	if genMsg.Parts[0].Text == nil || genMsg.Parts[0].Text.Content != "Hello!" {
 		t.Error("expected text part with 'Hello!'")
 	}
 }

--- a/bedrock/utils.go
+++ b/bedrock/utils.go
@@ -86,8 +86,8 @@ func extractSystemContent(message *genai.Message, options *genai.Options) []brty
 	// If the message itself is a system role, extract its text parts
 	if message != nil && message.Role == genai.RoleSystem {
 		for _, part := range message.Parts {
-			if part.Text != nil && part.Text.Text != "" {
-				blocks = append(blocks, &brtypes.SystemContentBlockMemberText{Value: part.Text.Text})
+			if part.Text != nil && part.Text.Content != "" {
+				blocks = append(blocks, &brtypes.SystemContentBlockMemberText{Value: part.Text.Content})
 			}
 		}
 	}
@@ -157,7 +157,7 @@ func convertMessage(msg *genai.Message) (brtypes.Message, error) {
 func convertPart(part *genai.Part) (brtypes.ContentBlock, error) {
 	switch {
 	case part.Text != nil:
-		return &brtypes.ContentBlockMemberText{Value: part.Text.Text}, nil
+		return &brtypes.ContentBlockMemberText{Value: part.Text.Content}, nil
 
 	case part.Bin != nil && ioutils.IsImageMime(part.MimeType):
 		format, err := mimeToImageFormat(part.MimeType)
@@ -329,7 +329,7 @@ func bedrockMessageToGenMessage(msg *brtypes.Message) *genai.Message {
 				genMsg.Parts = append(genMsg.Parts, genai.Part{
 					Name:     "text",
 					MimeType: ioutils.MimeTextPlain,
-					Text:     &genai.TextPart{Text: b.Value},
+					Text:     &genai.TextPart{Content: b.Value},
 				})
 			}
 

--- a/examples/bedrock/main.go
+++ b/examples/bedrock/main.go
@@ -96,7 +96,7 @@ for the country Japan. Only return the JSON, no other text.`)
 			if c.Message != nil {
 				for _, p := range c.Message.Parts {
 					if p.Text != nil {
-						fmt.Print(p.Text.Text)
+						fmt.Print(p.Text.Content)
 						streamTokens++
 					}
 				}
@@ -149,12 +149,12 @@ for the country Japan. Only return the JSON, no other text.`)
 			{
 				Name:     "context",
 				MimeType: "text/plain",
-				Text:     &genai.TextPart{Text: "The Eiffel Tower was built for the 1889 World's Fair in Paris."},
+				Text:     &genai.TextPart{Content: "The Eiffel Tower was built for the 1889 World's Fair in Paris."},
 			},
 			{
 				Name:     "question",
 				MimeType: "text/plain",
-				Text:     &genai.TextPart{Text: "When was the Eiffel Tower built and for what event?"},
+				Text:     &genai.TextPart{Content: "When was the Eiffel Tower built and for what event?"},
 			},
 		},
 	}
@@ -186,7 +186,7 @@ func printResponse(label string, resp *genai.GenResponse) {
 		if c.Message != nil {
 			for _, p := range c.Message.Parts {
 				if p.Text != nil {
-					text := p.Text.Text
+					text := p.Text.Content
 					if len(text) > 300 {
 						text = text[:300] + "..."
 					}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.1
 	github.com/aws/aws-sdk-go-v2/service/sns v1.39.12
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.22
-	oss.nandlabs.io/golly v1.3.0
+	oss.nandlabs.io/golly v1.4.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -44,5 +44,5 @@ github.com/aws/smithy-go v1.24.1 h1:VbyeNfmYkWoxMVpGUAbQumkODcYmfMRfZ8yQiH30SK0=
 github.com/aws/smithy-go v1.24.1/go.mod h1:LEj2LM3rBRQJxPZTB4KuzZkaZYnZPnvgIhb4pu07mx0=
 github.com/goccy/go-yaml v1.19.2 h1:PmFC1S6h8ljIz6gMRBopkjP1TVT7xuwrButHID66PoM=
 github.com/goccy/go-yaml v1.19.2/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
-oss.nandlabs.io/golly v1.3.0 h1:iuf/HjpRp0RR1GP+QoEBBICqlivXqbdfdQ60epM//4U=
-oss.nandlabs.io/golly v1.3.0/go.mod h1:Y97nuDQKtl64imdYPQIOpkbsMOpgBUxX+yQVJQSZ1Zw=
+oss.nandlabs.io/golly v1.4.0 h1:tN//uHvR4QHfIakFs3UBjP58VohFmgBI0eOL/1Q5y4M=
+oss.nandlabs.io/golly v1.4.0/go.mod h1:Y97nuDQKtl64imdYPQIOpkbsMOpgBUxX+yQVJQSZ1Zw=


### PR DESCRIPTION
## Description

Update all `TextPart.Text` references to `TextPart.Content` in the `bedrock` package to align with the upstream rename in `golly/genai` (nandlabs/golly#<!-- golly PR number -->). This eliminates the stuttering `part.Text.Text` accessor pattern in favor of the clearer `part.Text.Content`.

### Related Issue

Closes #<!-- issue number -->

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [x] 🔧 Refactoring (no functional changes)
- [x] ✅ Test update (adding or modifying tests)
- [ ] 🔨 Build / CI changes

## Changes Made

- Updated `bedrock/utils.go`:
  - `buildSystemBlocks` — `part.Text.Text` → `part.Text.Content`
  - `convertPart` — `part.Text.Text` → `part.Text.Content`
  - `bedrockMessageToGenMessage` — `TextPart{Text: ...}` → `TextPart{Content: ...}`
- Updated `bedrock/bedrock_test.go` — all test assertions referencing `.Text.Text` → `.Text.Content`
- Updated `examples/bedrock/main.go` — literal initializations and accessor references
- Bumped `golly` dependency to version with the `TextPart` rename

## Testing

- [x] I have added/updated unit tests for my changes
- [x] All existing tests pass (`go test ./...`)
- [x] I have tested this locally

### Test Output

```
# go test ./... output
```

## Checklist

- [x] My code follows the project's coding style and conventions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide

## Additional Context

This is a coordinated breaking change across the golly ecosystem. The upstream `golly/genai.TextPart.Text` field was renamed to `Content` — this PR updates `golly-aws` to compile against the new version. A matching PR exists for `golly-gcp`.