### PR TITLE
docs: add secrets package to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ## Overview
 
-Golly AWS provides AWS service implementations for core [Golly](https://github.com/nandlabs/golly) interfaces — VFS, Messaging, and GenAI. It uses the [AWS SDK for Go v2](https://github.com/aws/aws-sdk-go-v2) and follows Golly's provider pattern: blank-import a package to auto-register it, then use standard Golly managers with `s3://`, `sqs://`, or `sns://` URLs.
+Golly AWS provides AWS service implementations for core [Golly](https://github.com/nandlabs/golly) interfaces — VFS, Messaging, GenAI, and Secrets. It uses the [AWS SDK for Go v2](https://github.com/aws/aws-sdk-go-v2) and follows Golly's provider pattern: blank-import a package to auto-register it, then use standard Golly managers with `s3://`, `sqs://`, or `sns://` URLs.
 
 ## Installation
 
@@ -51,7 +51,13 @@ go get oss.nandlabs.io/golly-aws
 | ------------------ | ----------------------------------------------------------------------------------------------------- |
 | [s3](s3/README.md) | S3 implementation of the golly VFS interface — read, write, copy, move, list, walk, and directory ops |
 
-### 📡 Messaging
+### � Secrets
+
+| Package                      | Description                                                                                              |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------- |
+| [secrets](secrets/README.md) | AWS Secrets Manager implementation of the golly secrets store — get, write, delete, list with caching    |
+
+### �📡 Messaging
 
 | Package              | Description                                                                                 |
 | -------------------- | ------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Description

Update the main README to include the new `secrets` package in the overview and package table, reflecting the AWS Secrets Manager integration added in PR #113.

### Related Issue

Closes #113 follow-up — documentation was not updated in the original PR.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ✅ Test update (adding or modifying tests)
- [ ] 🔨 Build / CI changes

## Changes Made

- Updated overview text to mention Secrets alongside VFS, Messaging, and GenAI
- Added 🔐 Secrets section to the package table with link to `secrets/README.md`
- Description covers AWS Secrets Manager store capabilities: get, write, delete, list with caching

## Testing

- [ ] I have added/updated unit tests for my changes
- [x] All existing tests pass (`go test ./...`)
- [x] I have tested this locally

### Test Output

```
Documentation-only change — no test changes required.
```

## Checklist

- [x] My code follows the project's coding style and conventions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide

## Additional Context

This completes the documentation updates for the secrets package added in v0.3.0.