### PR TITLE
docs: add compatibility matrix and update install to v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,17 @@
 
 Golly AWS provides AWS service implementations for core [Golly](https://github.com/nandlabs/golly) interfaces — VFS, Messaging, GenAI, and Secrets. It uses the [AWS SDK for Go v2](https://github.com/aws/aws-sdk-go-v2) and follows Golly's provider pattern: blank-import a package to auto-register it, then use standard Golly managers with `s3://`, `sqs://`, or `sns://` URLs.
 
+## Compatibility
+
+| golly-aws | golly  | AWS SDK v2 |
+| --------- | ------ | ---------- |
+| v0.3.0    | v1.5.0 | v1.41.6    |
+| v0.2.0    | v1.4.0 | v1.41.2    |
+
 ## Installation
 
 ```bash
-go get oss.nandlabs.io/golly-aws
+go get oss.nandlabs.io/golly-aws@v0.3.0
 ```
 
 ## Packages


### PR DESCRIPTION
## Description

Add a compatibility matrix showing golly-aws, golly core, and AWS SDK v2 version mappings. Update the install command to pin v0.3.0.

### Related Issue

Follow-up to PR #113 (v0.3.0 release with AWS Secrets Manager store).

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ✅ Test update (adding or modifying tests)
- [ ] 🔨 Build / CI changes

## Changes Made

- Added **Compatibility** section with version matrix (golly-aws ↔ golly ↔ AWS SDK v2)
- Updated `go get` install command to `oss.nandlabs.io/golly-aws@v0.3.0`

## Testing

- [ ] I have added/updated unit tests for my changes
- [x] All existing tests pass (`go test ./...`)
- [x] I have tested this locally

### Test Output

```
Documentation-only change — no test changes required.
```

## Checklist

- [x] My code follows the project's coding style and conventions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide

## Additional Context

Adds version visibility so users can quickly check compatibility between golly-aws and golly core releases.