### PR TITLE
feat(auth/cognito): Cognito JWT verifier + DynamoDB session store

### DIFF
--- a/auth/cognito/README.md
+++ b/auth/cognito/README.md
@@ -1,0 +1,72 @@
+# auth/cognito
+
+AWS Cognito User Pool adapter for [`oss.nandlabs.io/golly/auth`](https://pkg.go.dev/oss.nandlabs.io/golly/auth).
+
+Ships two pluggable pieces:
+
+- **`Verifier`** — a JWKS-backed JWT verifier for Cognito User Pool
+  tokens. It fetches the public keys from
+  `https://cognito-idp.<region>.amazonaws.com/<userPoolID>/.well-known/jwks.json`,
+  caches them per-kid with a configurable TTL (default 1h) and
+  refreshes on demand when a token references an unknown kid. It
+  validates the RS256 signature, `iss` (`https://cognito-idp.<region>.amazonaws.com/<userPoolID>`),
+  `token_use` (accepts both `id` and `access` by default; narrow with
+  `WithTokenUse`), the app client id (via `WithAppClientID` — `aud`
+  for id-tokens, `client_id` for access-tokens), `exp` / `iat` with
+  a configurable leeway, and a non-empty `sub`. Cognito-specific
+  claims (`cognito:groups`, `cognito:username`, `token_use`,
+  `client_id`) are surfaced via `Claims.Extra`.
+- **`DynamoDBSessionStore`** — an `auth.SessionStore` backed by
+  Amazon DynamoDB. Sessions are `json.Marshal`ed into the `payload`
+  attribute of an item keyed by `id`; `user_id` and `expires_at`
+  mirror the session fields at the top level. A `ListByUser(ctx, uid)`
+  helper queries a Global Secondary Index named `userID-index`.
+
+## Quick start — verify a Cognito JWT in a `rest` handler
+
+```go
+import (
+    "net/http"
+
+    "oss.nandlabs.io/golly-aws/auth/cognito"
+    "oss.nandlabs.io/golly/rest"
+)
+
+func main() {
+    v, err := cognito.NewVerifier(
+        "us-east-1",
+        "us-east-1_ABCdef123",
+        cognito.WithAppClientID("your-app-client-id"),
+    )
+    if err != nil { panic(err) }
+    r := rest.NewRouter()
+    r.Get("/me", func(w http.ResponseWriter, req *http.Request) {
+        tok := req.Header.Get("Authorization")[len("Bearer "):]
+        claims, err := v.VerifyToken(req.Context(), tok)
+        if err != nil { http.Error(w, err.Error(), http.StatusUnauthorized); return }
+        w.Write([]byte("hello " + claims.Subject))
+    })
+    http.ListenAndServe(":8080", r)
+}
+```
+
+## Session store
+
+```go
+client := dynamodb.NewFromConfig(cfg)
+store := cognito.NewDynamoDBSessionStore(client, "sessions")
+sm := auth.NewSessionManager(store, auth.SessionConfig{Absolute: 24 * time.Hour})
+```
+
+### Table schema
+
+Partition key `id` (string). The store also writes `user_id` (S),
+`payload` (S — JSON) and `expires_at` (N — Unix seconds). To prune
+expired sessions server-side, **enable DynamoDB TTL on the table with
+`expires_at` as the TTL attribute** (AWS Console → Table → Additional
+settings → Time to live → attribute name `expires_at`).
+
+`ListByUser(ctx, uid)` requires a Global Secondary Index named
+`userID-index` with partition key `user_id` (S). If the GSI is
+absent the call returns an error wrapping `ErrNotSupported` with the
+verbatim DynamoDB `ValidationException`.

--- a/auth/cognito/doc.go
+++ b/auth/cognito/doc.go
@@ -1,0 +1,25 @@
+// Package cognito provides an AWS Cognito User Pool adapter for the
+// golly auth primitives.
+//
+// It ships two building blocks that plug into oss.nandlabs.io/golly/auth:
+//
+//   - Verifier: a JWKS-backed JWT verifier for tokens minted by an
+//     Amazon Cognito User Pool. It fetches the public keys from
+//     https://cognito-idp.<region>.amazonaws.com/<userPoolID>/.well-known/jwks.json,
+//     caches them per-kid with a configurable TTL, and validates the
+//     RS256 signature plus the issuer, token_use, audience/client_id,
+//     expiry and subject claims. Both id-tokens (token_use=id, aud) and
+//     access-tokens (token_use=access, client_id) are accepted by
+//     default; use WithTokenUse to narrow.
+//
+//   - DynamoDBSessionStore: an auth.SessionStore implementation backed
+//     by Amazon DynamoDB. Sessions are serialized as JSON documents
+//     keyed by session id and can be queried by their subject via the
+//     ListByUser helper (requires a GSI named "userID-index"). The
+//     mirrored expires_at attribute is Unix-seconds encoded and is
+//     suitable as the DynamoDB TTL attribute so expired sessions are
+//     pruned server-side.
+//
+// Neither type registers itself with any manager: callers wire them
+// explicitly into their golly auth verification or session middleware.
+package cognito

--- a/auth/cognito/session.go
+++ b/auth/cognito/session.go
@@ -1,0 +1,261 @@
+package cognito
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"oss.nandlabs.io/golly/auth"
+)
+
+// Attribute names used in the DynamoDB item schema. The partition key
+// is idAttr; the remaining attributes mirror auth.Session fields at the
+// top level so operators can query them without hydrating the JSON
+// payload.
+//
+// The table's partition key MUST be named "id" (string). The optional
+// "expires_at" attribute holds a Unix timestamp in seconds and is
+// suitable as the DynamoDB TTL attribute — operators should enable TTL
+// on that field so expired sessions are pruned server-side.
+const (
+	idAttr        = "id"
+	subjectAttr   = "user_id"
+	payloadAttr   = "payload"
+	expiresAtAttr = "expires_at"
+
+	// GSIUserIDIndex is the name of the optional Global Secondary Index
+	// that ListByUser queries. Create it with partition key user_id
+	// (string) to enable per-user session listing.
+	GSIUserIDIndex = "userID-index"
+)
+
+// ErrNotSupported is returned by ListByUser when the required GSI is
+// absent on the table. The wrapped error carries the verbatim DynamoDB
+// error so operators can diagnose without a round trip to CloudTrail.
+var ErrNotSupported = errors.New("auth/cognito: operation not supported by current table schema")
+
+// ddbAPI is the subset of the DynamoDB client used by the session
+// store. Extracted so tests can substitute a mock without needing
+// LocalStack or the DynamoDB emulator.
+type ddbAPI interface {
+	GetItem(ctx context.Context, in *dynamodb.GetItemInput, opts ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error)
+	PutItem(ctx context.Context, in *dynamodb.PutItemInput, opts ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error)
+	DeleteItem(ctx context.Context, in *dynamodb.DeleteItemInput, opts ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error)
+	Query(ctx context.Context, in *dynamodb.QueryInput, opts ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error)
+}
+
+// DynamoDBSessionStore persists auth.Session values in an Amazon
+// DynamoDB table. Each session is serialized via json.Marshal into the
+// payload attribute; user_id and expires_at mirror the session fields
+// so that operators can query them directly (and so DynamoDB TTL can
+// be enabled on expires_at). The table schema is:
+//
+//	partition key : id         (S)
+//	attribute     : user_id    (S)  — mirror of Session.Subject
+//	attribute     : payload    (S)  — JSON-encoded Session
+//	attribute     : expires_at (N)  — Unix seconds; use as TTL attribute
+//
+// Callers who want ListByUser must also create a Global Secondary Index
+// named GSIUserIDIndex with partition key user_id (S).
+type DynamoDBSessionStore struct {
+	api     ddbAPI
+	table   string
+	timeout time.Duration
+}
+
+// NewDynamoDBSessionStore constructs a session store backed by the
+// given DynamoDB client and table name. The returned type satisfies
+// auth.SessionStore and additionally exposes ListByUser.
+//
+// The caller is responsible for creating the table with the schema
+// documented on DynamoDBSessionStore. To auto-expire sessions, enable
+// DynamoDB TTL on the "expires_at" attribute (AWS Console → Table →
+// Additional settings → TTL attribute name = "expires_at").
+func NewDynamoDBSessionStore(client *dynamodb.Client, table string) *DynamoDBSessionStore {
+	if client == nil {
+		panic("auth/cognito: nil dynamodb.Client")
+	}
+	if table == "" {
+		panic("auth/cognito: empty table name")
+	}
+	return &DynamoDBSessionStore{api: client, table: table}
+}
+
+// newSessionStoreWithBackend is the unit-test constructor; production
+// callers should use NewDynamoDBSessionStore.
+func newSessionStoreWithBackend(api ddbAPI, table string) *DynamoDBSessionStore {
+	return &DynamoDBSessionStore{api: api, table: table}
+}
+
+// WithTimeout sets a per-call context deadline applied to every RPC.
+// A non-positive value clears the timeout.
+func (s *DynamoDBSessionStore) WithTimeout(d time.Duration) *DynamoDBSessionStore {
+	s.timeout = d
+	return s
+}
+
+// Get implements auth.SessionStore. Returns (nil, false) when the id is
+// unknown or on any transport error — the interface has no error
+// channel, so failures are silently swallowed (add a wrapping
+// SessionStore in your app if you need error observability).
+func (s *DynamoDBSessionStore) Get(id string) (*auth.Session, bool) {
+	if id == "" {
+		return nil, false
+	}
+	ctx, cancel := s.ctx()
+	defer cancel()
+	out, err := s.api.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(s.table),
+		Key: map[string]ddbtypes.AttributeValue{
+			idAttr: &ddbtypes.AttributeValueMemberS{Value: id},
+		},
+		ConsistentRead: aws.Bool(true),
+	})
+	if err != nil || out == nil || len(out.Item) == 0 {
+		return nil, false
+	}
+	sess, err := decodeSession(out.Item)
+	if err != nil {
+		return nil, false
+	}
+	return sess, true
+}
+
+// Put implements auth.SessionStore.
+func (s *DynamoDBSessionStore) Put(sess *auth.Session) error {
+	if sess == nil || sess.ID == "" {
+		return errors.New("auth/cognito: empty session id")
+	}
+	item, err := encodeSession(sess)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := s.ctx()
+	defer cancel()
+	_, err = s.api.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(s.table),
+		Item:      item,
+	})
+	return err
+}
+
+// Delete implements auth.SessionStore. Missing items are treated as a
+// success — callers of SessionStore.Delete typically already treat
+// idempotent revocation as the desired shape.
+func (s *DynamoDBSessionStore) Delete(id string) error {
+	if id == "" {
+		return errors.New("auth/cognito: empty session id")
+	}
+	ctx, cancel := s.ctx()
+	defer cancel()
+	_, err := s.api.DeleteItem(ctx, &dynamodb.DeleteItemInput{
+		TableName: aws.String(s.table),
+		Key: map[string]ddbtypes.AttributeValue{
+			idAttr: &ddbtypes.AttributeValueMemberS{Value: id},
+		},
+	})
+	return err
+}
+
+// ListByUser returns every session whose Subject equals uid. It queries
+// the Global Secondary Index named GSIUserIDIndex; if that index is
+// missing on the table, DynamoDB returns ValidationException — this
+// method surfaces the underlying error wrapped in ErrNotSupported with
+// a hint about the required GSI so operators can act on it.
+func (s *DynamoDBSessionStore) ListByUser(ctx context.Context, uid string) ([]*auth.Session, error) {
+	if uid == "" {
+		return nil, errors.New("auth/cognito: empty user id")
+	}
+	if s.timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, s.timeout)
+		defer cancel()
+	}
+	out, err := s.api.Query(ctx, &dynamodb.QueryInput{
+		TableName:              aws.String(s.table),
+		IndexName:              aws.String(GSIUserIDIndex),
+		KeyConditionExpression: aws.String("#u = :uid"),
+		ExpressionAttributeNames: map[string]string{
+			"#u": subjectAttr,
+		},
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+			":uid": &ddbtypes.AttributeValueMemberS{Value: uid},
+		},
+	})
+	if err != nil {
+		// DynamoDB returns ValidationException when the referenced
+		// index does not exist. Surface the raw error alongside
+		// ErrNotSupported so callers can errors.Is-check and still
+		// see what really happened.
+		return nil, fmt.Errorf("%w: create GSI %q with partition key %q (string) to enable ListByUser: %v",
+			ErrNotSupported, GSIUserIDIndex, subjectAttr, err)
+	}
+	sessions := make([]*auth.Session, 0, len(out.Items))
+	for _, item := range out.Items {
+		sess, err := decodeSession(item)
+		if err != nil {
+			return nil, fmt.Errorf("auth/cognito: decode item for uid %q: %w", uid, err)
+		}
+		sessions = append(sessions, sess)
+	}
+	return sessions, nil
+}
+
+// ctx returns a context that carries the configured timeout (or a
+// no-op cancel when timeout is 0).
+func (s *DynamoDBSessionStore) ctx() (context.Context, context.CancelFunc) {
+	if s.timeout <= 0 {
+		return context.Background(), func() {}
+	}
+	return context.WithTimeout(context.Background(), s.timeout)
+}
+
+// encodeSession marshals a session into a DynamoDB item using typed
+// attributes: id (S), user_id (S), payload (S), expires_at (N seconds).
+func encodeSession(sess *auth.Session) (map[string]ddbtypes.AttributeValue, error) {
+	b, err := json.Marshal(sess)
+	if err != nil {
+		return nil, fmt.Errorf("auth/cognito: marshal session: %w", err)
+	}
+	item := map[string]ddbtypes.AttributeValue{
+		idAttr:      &ddbtypes.AttributeValueMemberS{Value: sess.ID},
+		subjectAttr: &ddbtypes.AttributeValueMemberS{Value: sess.Subject},
+		payloadAttr: &ddbtypes.AttributeValueMemberS{Value: string(b)},
+	}
+	if !sess.ExpiresAt.IsZero() {
+		item[expiresAtAttr] = &ddbtypes.AttributeValueMemberN{
+			Value: strconv.FormatInt(sess.ExpiresAt.Unix(), 10),
+		}
+	}
+	return item, nil
+}
+
+// decodeSession recovers a session from a DynamoDB item. The payload
+// attribute holds the JSON round-trip source of truth; mirrored
+// user_id/expires_at fields are ignored on read.
+func decodeSession(item map[string]ddbtypes.AttributeValue) (*auth.Session, error) {
+	raw, ok := item[payloadAttr]
+	if !ok {
+		return nil, fmt.Errorf("auth/cognito: item missing %q attribute", payloadAttr)
+	}
+	var payload []byte
+	switch v := raw.(type) {
+	case *ddbtypes.AttributeValueMemberS:
+		payload = []byte(v.Value)
+	case *ddbtypes.AttributeValueMemberB:
+		payload = v.Value
+	default:
+		return nil, fmt.Errorf("auth/cognito: %q attribute has unsupported type %T", payloadAttr, raw)
+	}
+	var sess auth.Session
+	if err := json.Unmarshal(payload, &sess); err != nil {
+		return nil, fmt.Errorf("auth/cognito: unmarshal session: %w", err)
+	}
+	return &sess, nil
+}

--- a/auth/cognito/session_test.go
+++ b/auth/cognito/session_test.go
@@ -1,0 +1,354 @@
+package cognito
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sort"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"oss.nandlabs.io/golly/auth"
+)
+
+// memDDB is an in-memory ddbAPI that mirrors DynamoDB's Item shape
+// (map[string]AttributeValue per row) so it exercises the same
+// encode/decode paths as the real client. Query filters on user_id
+// (the mirrored subject attribute) — matching the GSI schema
+// documented on DynamoDBSessionStore.
+type memDDB struct {
+	mu     sync.Mutex
+	table  string
+	items  map[string]map[string]ddbtypes.AttributeValue
+	failOn string // when set, matching op returns errBoom
+	// Optional Query hook so tests can simulate ValidationException
+	// (missing GSI) surfacing through ListByUser.
+	queryErr error
+}
+
+var errBoom = errors.New("boom")
+
+func newMemDDB(table string) *memDDB {
+	return &memDDB{
+		table: table,
+		items: make(map[string]map[string]ddbtypes.AttributeValue),
+	}
+}
+
+func (m *memDDB) GetItem(_ context.Context, in *dynamodb.GetItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.failOn == "GetItem" {
+		return nil, errBoom
+	}
+	if aws.ToString(in.TableName) != m.table {
+		return nil, errors.New("wrong table")
+	}
+	idAV, ok := in.Key[idAttr].(*ddbtypes.AttributeValueMemberS)
+	if !ok {
+		return nil, errors.New("bad key")
+	}
+	item, ok := m.items[idAV.Value]
+	if !ok {
+		return &dynamodb.GetItemOutput{}, nil
+	}
+	// Return a clone so mutations by the caller don't leak into the store.
+	out := make(map[string]ddbtypes.AttributeValue, len(item))
+	for k, v := range item {
+		out[k] = v
+	}
+	return &dynamodb.GetItemOutput{Item: out}, nil
+}
+
+func (m *memDDB) PutItem(_ context.Context, in *dynamodb.PutItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.failOn == "PutItem" {
+		return nil, errBoom
+	}
+	if aws.ToString(in.TableName) != m.table {
+		return nil, errors.New("wrong table")
+	}
+	idAV, ok := in.Item[idAttr].(*ddbtypes.AttributeValueMemberS)
+	if !ok {
+		return nil, errors.New("missing id attr")
+	}
+	clone := make(map[string]ddbtypes.AttributeValue, len(in.Item))
+	for k, v := range in.Item {
+		clone[k] = v
+	}
+	m.items[idAV.Value] = clone
+	return &dynamodb.PutItemOutput{}, nil
+}
+
+func (m *memDDB) DeleteItem(_ context.Context, in *dynamodb.DeleteItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.failOn == "DeleteItem" {
+		return nil, errBoom
+	}
+	if aws.ToString(in.TableName) != m.table {
+		return nil, errors.New("wrong table")
+	}
+	idAV, ok := in.Key[idAttr].(*ddbtypes.AttributeValueMemberS)
+	if !ok {
+		return nil, errors.New("bad key")
+	}
+	delete(m.items, idAV.Value)
+	return &dynamodb.DeleteItemOutput{}, nil
+}
+
+func (m *memDDB) Query(_ context.Context, in *dynamodb.QueryInput, _ ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.queryErr != nil {
+		return nil, m.queryErr
+	}
+	if aws.ToString(in.IndexName) != GSIUserIDIndex {
+		return nil, errors.New("query targets unexpected index: " + aws.ToString(in.IndexName))
+	}
+	uidAV, ok := in.ExpressionAttributeValues[":uid"].(*ddbtypes.AttributeValueMemberS)
+	if !ok {
+		return nil, errors.New("missing :uid binding")
+	}
+	var out []map[string]ddbtypes.AttributeValue
+	for _, item := range m.items {
+		sub, ok := item[subjectAttr].(*ddbtypes.AttributeValueMemberS)
+		if !ok {
+			continue
+		}
+		if sub.Value == uidAV.Value {
+			out = append(out, item)
+		}
+	}
+	return &dynamodb.QueryOutput{Items: out, Count: int32(len(out))}, nil
+}
+
+func newTestStore() (*DynamoDBSessionStore, *memDDB) {
+	backend := newMemDDB("sessions")
+	return newSessionStoreWithBackend(backend, "sessions"), backend
+}
+
+func mkSession(id, sub string) *auth.Session {
+	now := time.Now().UTC().Truncate(time.Second)
+	return &auth.Session{
+		ID:        id,
+		Subject:   sub,
+		CreatedAt: now,
+		LastSeen:  now,
+		ExpiresAt: now.Add(time.Hour),
+		Data:      map[string]any{"role": "user"},
+	}
+}
+
+func TestSessionStore_PutGetRoundTrip(t *testing.T) {
+	s, _ := newTestStore()
+	sess := mkSession("sid-1", "user-1")
+	if err := s.Put(sess); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, ok := s.Get(sess.ID)
+	if !ok {
+		t.Fatal("Get: not found after Put")
+	}
+	if got.ID != sess.ID || got.Subject != sess.Subject {
+		t.Errorf("got %+v want %+v", got, sess)
+	}
+	if !got.ExpiresAt.Equal(sess.ExpiresAt) {
+		t.Errorf("ExpiresAt: got %v want %v", got.ExpiresAt, sess.ExpiresAt)
+	}
+	if got.Data["role"] != "user" {
+		t.Errorf("Data lost in round trip: %+v", got.Data)
+	}
+}
+
+func TestSessionStore_GetMissing(t *testing.T) {
+	s, _ := newTestStore()
+	if _, ok := s.Get("nope"); ok {
+		t.Fatal("Get on empty store returned ok")
+	}
+	if _, ok := s.Get(""); ok {
+		t.Fatal("Get(\"\") should return false")
+	}
+}
+
+func TestSessionStore_Delete(t *testing.T) {
+	s, _ := newTestStore()
+	if err := s.Put(mkSession("sid-1", "user-1")); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Delete("sid-1"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, ok := s.Get("sid-1"); ok {
+		t.Fatal("session still present after Delete")
+	}
+	// Idempotent: deleting a missing session is not an error.
+	if err := s.Delete("sid-1"); err != nil {
+		t.Fatalf("Delete (idempotent): %v", err)
+	}
+	if err := s.Delete(""); err == nil {
+		t.Fatal("Delete(\"\") should error on empty id")
+	}
+}
+
+func TestSessionStore_PutEmptyIDFails(t *testing.T) {
+	s, _ := newTestStore()
+	if err := s.Put(&auth.Session{ID: ""}); err == nil {
+		t.Fatal("Put with empty id: expected error")
+	}
+	if err := s.Put(nil); err == nil {
+		t.Fatal("Put(nil): expected error")
+	}
+}
+
+func TestSessionStore_ListByUser(t *testing.T) {
+	s, _ := newTestStore()
+	for i, tc := range []struct {
+		id, sub string
+	}{
+		{"a", "user-1"},
+		{"b", "user-1"},
+		{"c", "user-2"},
+	} {
+		if err := s.Put(mkSession(tc.id, tc.sub)); err != nil {
+			t.Fatalf("Put[%d]: %v", i, err)
+		}
+	}
+	got, err := s.ListByUser(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("ListByUser: %v", err)
+	}
+	ids := make([]string, len(got))
+	for i, g := range got {
+		ids[i] = g.ID
+	}
+	sort.Strings(ids)
+	if len(ids) != 2 || ids[0] != "a" || ids[1] != "b" {
+		t.Errorf("ListByUser user-1: got %v want [a b]", ids)
+	}
+
+	empty, err := s.ListByUser(context.Background(), "user-3")
+	if err != nil {
+		t.Fatalf("ListByUser (empty): %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("ListByUser user-3: got %d, want 0", len(empty))
+	}
+
+	if _, err := s.ListByUser(context.Background(), ""); err == nil {
+		t.Fatal("ListByUser(\"\"): expected error")
+	}
+}
+
+func TestSessionStore_ListByUser_MissingGSI(t *testing.T) {
+	s, backend := newTestStore()
+	// Simulate DynamoDB's ValidationException when the target index is
+	// not defined on the table.
+	backend.queryErr = errors.New("ValidationException: The table does not have the specified index: userID-index")
+
+	_, err := s.ListByUser(context.Background(), "user-1")
+	if err == nil {
+		t.Fatal("expected error from ListByUser when GSI is missing")
+	}
+	if !errors.Is(err, ErrNotSupported) {
+		t.Errorf("expected ErrNotSupported wrap; got %v", err)
+	}
+	if got := err.Error(); !contains(got, "userID-index") || !contains(got, "ValidationException") {
+		t.Errorf("wrapped error should include index name and DynamoDB message; got %q", got)
+	}
+}
+
+func TestSessionStore_PayloadIsJSON(t *testing.T) {
+	// Confirm the stored item really uses json.Marshal — inspect the
+	// payload attribute directly through the in-memory backend.
+	s, backend := newTestStore()
+	sess := mkSession("sid-1", "user-1")
+	if err := s.Put(sess); err != nil {
+		t.Fatal(err)
+	}
+	item := backend.items[sess.ID]
+	raw, ok := item[payloadAttr].(*ddbtypes.AttributeValueMemberS)
+	if !ok {
+		t.Fatalf("payload attribute missing or wrong type; item=%v", item)
+	}
+	var round auth.Session
+	if err := json.Unmarshal([]byte(raw.Value), &round); err != nil {
+		t.Fatalf("payload not valid JSON: %v", err)
+	}
+	if round.Subject != sess.Subject {
+		t.Errorf("json round-trip subject: got %q want %q", round.Subject, sess.Subject)
+	}
+	if s2, ok := item[subjectAttr].(*ddbtypes.AttributeValueMemberS); !ok || s2.Value != sess.Subject {
+		t.Errorf("mirrored user_id attribute: got %v want %q", item[subjectAttr], sess.Subject)
+	}
+	// expires_at attribute must carry the Unix-seconds string used by DynamoDB TTL.
+	exp, ok := item[expiresAtAttr].(*ddbtypes.AttributeValueMemberN)
+	if !ok {
+		t.Fatalf("expires_at attribute missing; item=%v", item)
+	}
+	if want := strconv.FormatInt(sess.ExpiresAt.Unix(), 10); exp.Value != want {
+		t.Errorf("expires_at: got %q want %q", exp.Value, want)
+	}
+}
+
+func TestSessionStore_PayloadBinaryBackend(t *testing.T) {
+	// Confirm decodeSession also accepts a B (binary) payload — some
+	// callers may prefer binary attributes for the JSON payload.
+	s, backend := newTestStore()
+	sess := mkSession("sid-1", "user-1")
+	if err := s.Put(sess); err != nil {
+		t.Fatal(err)
+	}
+	item := backend.items[sess.ID]
+	if av, ok := item[payloadAttr].(*ddbtypes.AttributeValueMemberS); ok {
+		item[payloadAttr] = &ddbtypes.AttributeValueMemberB{Value: []byte(av.Value)}
+	}
+	got, ok := s.Get(sess.ID)
+	if !ok {
+		t.Fatal("Get after binary re-encode: not found")
+	}
+	if got.Subject != sess.Subject {
+		t.Errorf("subject: got %q want %q", got.Subject, sess.Subject)
+	}
+}
+
+func TestSessionStore_GetSwallowsTransportError(t *testing.T) {
+	backend := newMemDDB("sessions")
+	backend.failOn = "GetItem"
+	s := newSessionStoreWithBackend(backend, "sessions")
+	if _, ok := s.Get("x"); ok {
+		t.Fatal("Get: expected (nil,false) on transport error")
+	}
+}
+
+func TestSessionStore_DeletePropagatesTransportError(t *testing.T) {
+	backend := newMemDDB("sessions")
+	backend.failOn = "DeleteItem"
+	s := newSessionStoreWithBackend(backend, "sessions")
+	if err := s.Delete("x"); err == nil {
+		t.Fatal("Delete: expected error to propagate")
+	}
+}
+
+// contains is a tiny helper to keep the test-only imports clean.
+func contains(s, sub string) bool {
+	return len(sub) == 0 || (len(s) >= len(sub) && indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+// Compile-time assertion: *DynamoDBSessionStore satisfies auth.SessionStore.
+var _ auth.SessionStore = (*DynamoDBSessionStore)(nil)

--- a/auth/cognito/verifier.go
+++ b/auth/cognito/verifier.go
@@ -1,0 +1,446 @@
+package cognito
+
+import (
+	"context"
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"oss.nandlabs.io/golly/auth"
+)
+
+// Cognito token_use claim values. Access tokens carry a client_id claim
+// but no aud; ID tokens carry aud but no client_id.
+const (
+	TokenUseID     = "id"
+	TokenUseAccess = "access"
+)
+
+// DefaultKeyTTL is the fallback cache lifetime for JWKS entries when
+// WithKeyTTL is not supplied. Cognito rotates signing keys infrequently
+// so an hour is a conservative default.
+const DefaultKeyTTL = time.Hour
+
+// DefaultLeeway is the clock-skew allowance used when validating exp and
+// iat during VerifyToken.
+const DefaultLeeway = 60 * time.Second
+
+// IssuerPrefix is prepended to "<region>.amazonaws.com/<userPoolID>" to
+// form the expected iss claim on Cognito-minted tokens.
+const IssuerPrefix = "https://cognito-idp."
+
+// jwksPath is appended to the issuer URL to obtain the JWKS endpoint.
+const jwksPath = "/.well-known/jwks.json"
+
+// Verifier is a Cognito User Pool JWT verifier. It caches JWKS entries
+// per-kid and refreshes them on demand when a token references an
+// unknown kid. Verifier is safe for concurrent use.
+type Verifier struct {
+	region      string
+	userPoolID  string
+	issuer      string
+	jwksURL     string
+	appClientID string
+	tokenUses   map[string]struct{}
+	ttl         time.Duration
+	leeway      time.Duration
+	httpc       *http.Client
+	now         func() time.Time
+
+	mu   sync.RWMutex
+	keys map[string]*keyEntry
+}
+
+type keyEntry struct {
+	pub     *rsa.PublicKey
+	expires time.Time
+}
+
+// Option customizes a Verifier at construction time.
+type Option func(*Verifier)
+
+// WithJWKSURL overrides the JWKS endpoint. Primarily used by tests.
+func WithJWKSURL(url string) Option { return func(v *Verifier) { v.jwksURL = url } }
+
+// WithHTTPClient overrides the HTTP client used to fetch JWKS.
+func WithHTTPClient(c *http.Client) Option {
+	return func(v *Verifier) {
+		if c != nil {
+			v.httpc = c
+		}
+	}
+}
+
+// WithKeyTTL sets the cache lifetime for fetched JWKS entries.
+func WithKeyTTL(d time.Duration) Option {
+	return func(v *Verifier) {
+		if d > 0 {
+			v.ttl = d
+		}
+	}
+}
+
+// WithLeeway sets the clock-skew allowance used by VerifyToken.
+func WithLeeway(d time.Duration) Option {
+	return func(v *Verifier) {
+		if d >= 0 {
+			v.leeway = d
+		}
+	}
+}
+
+// WithNow overrides the time source used by VerifyToken. Primarily used
+// by tests to exercise expired/not-yet-valid paths.
+func WithNow(fn func() time.Time) Option {
+	return func(v *Verifier) {
+		if fn != nil {
+			v.now = fn
+		}
+	}
+}
+
+// WithAppClientID pins the expected Cognito app client id. When set,
+// VerifyToken requires:
+//   - id tokens:     aud == clientID
+//   - access tokens: client_id (claim) == clientID
+//
+// When unset (the default) the client-id check is skipped.
+func WithAppClientID(clientID string) Option {
+	return func(v *Verifier) { v.appClientID = clientID }
+}
+
+// WithTokenUse restricts the accepted token_use values. Pass one or
+// both of TokenUseID / TokenUseAccess. When omitted, the verifier
+// accepts either token flavour, matching Cognito's own guidance that
+// most APIs consume access tokens while apps consume id tokens.
+func WithTokenUse(uses ...string) Option {
+	return func(v *Verifier) {
+		if len(uses) == 0 {
+			return
+		}
+		set := make(map[string]struct{}, len(uses))
+		for _, u := range uses {
+			set[u] = struct{}{}
+		}
+		v.tokenUses = set
+	}
+}
+
+// NewVerifier constructs a Cognito JWT verifier for the given region
+// and User Pool id. The returned *Verifier implements auth.Verifier and
+// can be plugged into auth.VerifyOptions.VerifierFallback; VerifyToken
+// is the recommended entry point for typical usage.
+func NewVerifier(region, userPoolID string, opts ...Option) (*Verifier, error) {
+	if region == "" {
+		return nil, errors.New("auth/cognito: region is required")
+	}
+	if userPoolID == "" {
+		return nil, errors.New("auth/cognito: userPoolID is required")
+	}
+	issuer := IssuerPrefix + region + ".amazonaws.com/" + userPoolID
+	v := &Verifier{
+		region:     region,
+		userPoolID: userPoolID,
+		issuer:     issuer,
+		jwksURL:    issuer + jwksPath,
+		tokenUses: map[string]struct{}{
+			TokenUseID:     {},
+			TokenUseAccess: {},
+		},
+		ttl:    DefaultKeyTTL,
+		leeway: DefaultLeeway,
+		httpc:  http.DefaultClient,
+		now:    time.Now,
+		keys:   make(map[string]*keyEntry),
+	}
+	for _, o := range opts {
+		o(v)
+	}
+	return v, nil
+}
+
+// Alg reports the algorithm this verifier validates. Cognito always
+// signs with RS256.
+func (v *Verifier) Alg() string { return auth.AlgRS256 }
+
+// Verify implements auth.Verifier by extracting the kid from the JWS
+// header carried in signingInput, resolving the RSA public key (with a
+// JWKS refresh on unknown kid), and validating the RS256 signature.
+// It does not perform claim validation — for that use VerifyToken.
+func (v *Verifier) Verify(signingInput, sig []byte) error {
+	dot := indexByte(signingInput, '.')
+	if dot < 0 {
+		return auth.ErrInvalidToken
+	}
+	hdrB, err := base64.RawURLEncoding.DecodeString(string(signingInput[:dot]))
+	if err != nil {
+		return auth.ErrInvalidToken
+	}
+	var hdr auth.Header
+	if err := json.Unmarshal(hdrB, &hdr); err != nil {
+		return auth.ErrInvalidToken
+	}
+	if hdr.Alg != auth.AlgRS256 {
+		return auth.ErrAlgNotAllowed
+	}
+	if hdr.Kid == "" {
+		return fmt.Errorf("%w: token missing kid", auth.ErrKeyNotFound)
+	}
+	pub, err := v.keyForKid(context.Background(), hdr.Kid)
+	if err != nil {
+		return fmt.Errorf("%w: %v", auth.ErrKeyNotFound, err)
+	}
+	sum := sha256.Sum256(signingInput)
+	if err := rsa.VerifyPKCS1v15(pub, crypto.SHA256, sum[:], sig); err != nil {
+		return auth.ErrInvalidSig
+	}
+	return nil
+}
+
+// Keyset returns an auth.Verifier bound to a specific kid. Suitable for
+// wiring into auth.VerifyOptions.Keyset when the caller prefers
+// explicit per-kid dispatch over Verifier's own header parse.
+func (v *Verifier) Keyset(kid string) (auth.Verifier, error) {
+	pub, err := v.keyForKid(context.Background(), kid)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", auth.ErrKeyNotFound, err)
+	}
+	return auth.NewRSVerifier(auth.AlgRS256, pub)
+}
+
+// VerifyToken parses, signature-checks and claim-validates a compact
+// Cognito-issued JWT. It enforces:
+//   - alg = RS256
+//   - iss = https://cognito-idp.<region>.amazonaws.com/<userPoolID>
+//   - token_use is one of the configured values (default: id or access)
+//   - if WithAppClientID is set:
+//     id-tokens: aud contains the client id
+//     access-tokens: client_id claim equals the client id
+//   - exp is in the future (with configured leeway)
+//   - iat is in the past  (with configured leeway)
+//   - sub is non-empty
+//
+// The returned Claims carry the RFC 7519 registered fields; Cognito-
+// specific claims (cognito:groups, cognito:username, token_use,
+// client_id) are surfaced via Claims.Extra.
+func (v *Verifier) VerifyToken(ctx context.Context, token string) (*auth.Claims, error) {
+	// Prime the JWKS cache using the caller-supplied context so that
+	// the network fetch respects any request-scoped deadline.
+	if kid := peekKid(token); kid != "" {
+		if _, err := v.keyForKid(ctx, kid); err != nil {
+			return nil, fmt.Errorf("%w: %v", auth.ErrKeyNotFound, err)
+		}
+	}
+	claims, err := auth.Verify(token, auth.VerifyOptions{
+		Algs:             []string{auth.AlgRS256},
+		VerifierFallback: v,
+		Issuer:           v.issuer,
+		// Audience is checked manually because Cognito access tokens
+		// carry client_id instead of aud; auth.VerifyOptions.Audience
+		// would reject them.
+		Leeway: v.leeway,
+		Now:    v.now,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if claims.Subject == "" {
+		return nil, fmt.Errorf("%w: sub claim is empty", auth.ErrInvalidToken)
+	}
+	if claims.IssuedAt != nil {
+		if claims.IssuedAt.After(v.now().Add(v.leeway)) {
+			return nil, auth.ErrNotYetValid
+		}
+	}
+	tokenUse, _ := claims.Extra["token_use"].(string)
+	if tokenUse == "" {
+		return nil, fmt.Errorf("%w: token_use claim is missing", auth.ErrInvalidToken)
+	}
+	if _, ok := v.tokenUses[tokenUse]; !ok {
+		return nil, fmt.Errorf("%w: token_use %q not accepted", auth.ErrInvalidToken, tokenUse)
+	}
+	if v.appClientID != "" {
+		switch tokenUse {
+		case TokenUseID:
+			ok := false
+			for _, a := range claims.Audience {
+				if a == v.appClientID {
+					ok = true
+					break
+				}
+			}
+			if !ok {
+				return nil, auth.ErrAudMismatch
+			}
+		case TokenUseAccess:
+			cid, _ := claims.Extra["client_id"].(string)
+			if cid != v.appClientID {
+				return nil, auth.ErrAudMismatch
+			}
+		}
+	}
+	return claims, nil
+}
+
+// keyForKid returns the cached public key for kid, refreshing the JWKS
+// on a cache miss or when the cached entry has expired.
+func (v *Verifier) keyForKid(ctx context.Context, kid string) (*rsa.PublicKey, error) {
+	now := v.now()
+	v.mu.RLock()
+	entry, ok := v.keys[kid]
+	v.mu.RUnlock()
+	if ok && now.Before(entry.expires) {
+		return entry.pub, nil
+	}
+	if err := v.refresh(ctx); err != nil {
+		return nil, err
+	}
+	v.mu.RLock()
+	entry, ok = v.keys[kid]
+	v.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("kid %q not present in JWKS", kid)
+	}
+	return entry.pub, nil
+}
+
+// jwks is the shape returned by Cognito's .well-known/jwks.json.
+type jwks struct {
+	Keys []jwk `json:"keys"`
+}
+
+// jwk carries the fields we care about from a JSON Web Key. Cognito
+// always publishes RSA public keys, so kty is expected to be "RSA".
+type jwk struct {
+	Kid string `json:"kid"`
+	Kty string `json:"kty"`
+	Alg string `json:"alg"`
+	Use string `json:"use"`
+	N   string `json:"n"`
+	E   string `json:"e"`
+}
+
+// refresh fetches the JWKS and replaces the in-memory cache. It uses a
+// write lock across the network call so concurrent misses collapse into
+// a single fetch.
+func (v *Verifier) refresh(ctx context.Context) error {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, v.jwksURL, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := v.httpc.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("auth/cognito: JWKS fetch returned %s", resp.Status)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	var set jwks
+	if err := json.Unmarshal(body, &set); err != nil {
+		return fmt.Errorf("auth/cognito: decode JWKS: %w", err)
+	}
+	if len(set.Keys) == 0 {
+		return errors.New("auth/cognito: JWKS response contains no keys")
+	}
+	next := make(map[string]*keyEntry, len(set.Keys))
+	exp := v.now().Add(v.ttl)
+	for _, k := range set.Keys {
+		if k.Kty != "" && k.Kty != "RSA" {
+			// Skip non-RSA keys silently — Cognito only publishes RSA
+			// but be tolerant of a future JWKS shape.
+			continue
+		}
+		if k.Alg != "" && k.Alg != auth.AlgRS256 {
+			continue
+		}
+		pub, err := parseRSAPublicKeyFromJWK(k)
+		if err != nil {
+			return fmt.Errorf("auth/cognito: kid %q: %w", k.Kid, err)
+		}
+		next[k.Kid] = &keyEntry{pub: pub, expires: exp}
+	}
+	if len(next) == 0 {
+		return errors.New("auth/cognito: JWKS contained no usable RS256 keys")
+	}
+	v.keys = next
+	return nil
+}
+
+// parseRSAPublicKeyFromJWK reconstructs an *rsa.PublicKey from the
+// base64url-encoded modulus (n) and exponent (e) fields of a JWK.
+func parseRSAPublicKeyFromJWK(k jwk) (*rsa.PublicKey, error) {
+	if k.N == "" || k.E == "" {
+		return nil, errors.New("JWK missing n or e")
+	}
+	nb, err := base64.RawURLEncoding.DecodeString(k.N)
+	if err != nil {
+		return nil, fmt.Errorf("decode n: %w", err)
+	}
+	eb, err := base64.RawURLEncoding.DecodeString(k.E)
+	if err != nil {
+		return nil, fmt.Errorf("decode e: %w", err)
+	}
+	// The exponent is a big-endian byte string; left-pad to 4 bytes so
+	// binary.BigEndian.Uint32 can decode it directly.
+	if len(eb) > 4 {
+		return nil, fmt.Errorf("exponent too large (%d bytes)", len(eb))
+	}
+	padded := make([]byte, 4)
+	copy(padded[4-len(eb):], eb)
+	e := int(binary.BigEndian.Uint32(padded))
+	if e <= 0 {
+		return nil, errors.New("non-positive exponent")
+	}
+	return &rsa.PublicKey{
+		N: new(big.Int).SetBytes(nb),
+		E: e,
+	}, nil
+}
+
+// peekKid extracts the kid header from a compact JWT without any
+// signature check. It returns "" on any parse error — the subsequent
+// Verify pass will surface the specific problem.
+func peekKid(token string) string {
+	dot := strings.IndexByte(token, '.')
+	if dot < 0 {
+		return ""
+	}
+	hb, err := base64.RawURLEncoding.DecodeString(token[:dot])
+	if err != nil {
+		return ""
+	}
+	var h auth.Header
+	if err := json.Unmarshal(hb, &h); err != nil {
+		return ""
+	}
+	return h.Kid
+}
+
+// indexByte is a byte-slice equivalent of strings.IndexByte; inlined
+// here to avoid a string conversion on the hot signature-verify path.
+func indexByte(b []byte, c byte) int {
+	for i, x := range b {
+		if x == c {
+			return i
+		}
+	}
+	return -1
+}

--- a/auth/cognito/verifier_test.go
+++ b/auth/cognito/verifier_test.go
@@ -1,0 +1,355 @@
+package cognito
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"oss.nandlabs.io/golly/auth"
+)
+
+// testSigner bundles an RSA key + kid to keep test tokens compact.
+type testSigner struct {
+	kid string
+	key *rsa.PrivateKey
+}
+
+func newTestSigner(t *testing.T, kid string) *testSigner {
+	t.Helper()
+	k, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+	return &testSigner{kid: kid, key: k}
+}
+
+// jwk returns the JWK dict entry (kid, kty=RSA, n, e, alg=RS256) that
+// mirrors what Cognito publishes at .well-known/jwks.json.
+func (s *testSigner) jwk() map[string]string {
+	pub := s.key.PublicKey
+	// Big-endian encoding of the exponent, trimmed of leading zeros.
+	eBuf := make([]byte, 4)
+	binary.BigEndian.PutUint32(eBuf, uint32(pub.E))
+	i := 0
+	for i < len(eBuf)-1 && eBuf[i] == 0 {
+		i++
+	}
+	return map[string]string{
+		"kid": s.kid,
+		"kty": "RSA",
+		"alg": auth.AlgRS256,
+		"use": "sig",
+		"n":   base64.RawURLEncoding.EncodeToString(pub.N.Bytes()),
+		"e":   base64.RawURLEncoding.EncodeToString(eBuf[i:]),
+	}
+}
+
+// mint builds a signed compact JWT using RS256 with the signer's kid
+// baked into the header.
+func (s *testSigner) mint(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	hdr := map[string]any{"alg": auth.AlgRS256, "typ": "JWT", "kid": s.kid}
+	hb, _ := json.Marshal(hdr)
+	pb, _ := json.Marshal(claims)
+	signingInput := base64.RawURLEncoding.EncodeToString(hb) + "." + base64.RawURLEncoding.EncodeToString(pb)
+	sum := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, s.key, crypto.SHA256, sum[:])
+	if err != nil {
+		t.Fatalf("rsa.SignPKCS1v15: %v", err)
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig)
+}
+
+// jwksServer serves a Cognito-shaped JWKS response ({"keys":[...]}).
+// Each request bumps the atomic hit counter so tests can assert on
+// refresh behavior.
+type jwksServer struct {
+	*httptest.Server
+	hits atomic.Int64
+	body atomic.Value // string
+}
+
+func newJWKSServer(t *testing.T, signers ...*testSigner) *jwksServer {
+	t.Helper()
+	js := &jwksServer{}
+	js.setSigners(signers...)
+	js.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		js.hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(js.body.Load().(string)))
+	}))
+	t.Cleanup(js.Close)
+	return js
+}
+
+func (js *jwksServer) setSigners(signers ...*testSigner) {
+	keys := make([]map[string]string, 0, len(signers))
+	for _, s := range signers {
+		keys = append(keys, s.jwk())
+	}
+	b, _ := json.Marshal(map[string]any{"keys": keys})
+	js.body.Store(string(b))
+}
+
+// idClaims returns a valid id-token claim set for the given signer and
+// user pool identifier. Individual tests mutate the map before minting.
+func idClaims(region, userPoolID, clientID, sub string) map[string]any {
+	now := time.Now()
+	return map[string]any{
+		"iss":       IssuerPrefix + region + ".amazonaws.com/" + userPoolID,
+		"aud":       clientID,
+		"sub":       sub,
+		"token_use": TokenUseID,
+		"iat":       now.Add(-time.Minute).Unix(),
+		"exp":       now.Add(time.Hour).Unix(),
+	}
+}
+
+// accessClaims returns a valid access-token claim set. Cognito access
+// tokens carry client_id (not aud) and token_use=access.
+func accessClaims(region, userPoolID, clientID, sub string) map[string]any {
+	now := time.Now()
+	return map[string]any{
+		"iss":       IssuerPrefix + region + ".amazonaws.com/" + userPoolID,
+		"client_id": clientID,
+		"sub":       sub,
+		"token_use": TokenUseAccess,
+		"iat":       now.Add(-time.Minute).Unix(),
+		"exp":       now.Add(time.Hour).Unix(),
+	}
+}
+
+func newVerifier(t *testing.T, region, userPoolID string, jwks *jwksServer, opts ...Option) *Verifier {
+	t.Helper()
+	full := append([]Option{WithJWKSURL(jwks.URL)}, opts...)
+	v, err := NewVerifier(region, userPoolID, full...)
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	return v
+}
+
+const (
+	testRegion = "us-east-1"
+	testPool   = "us-east-1_ABCdef123"
+	testClient = "abcdefghijklmnop"
+)
+
+func TestVerify_ValidIDToken_Success(t *testing.T) {
+	signer := newTestSigner(t, "kid-1")
+	jwks := newJWKSServer(t, signer)
+	v := newVerifier(t, testRegion, testPool, jwks, WithAppClientID(testClient))
+
+	claims := idClaims(testRegion, testPool, testClient, "user-42")
+	claims["cognito:username"] = "alice"
+	claims["cognito:groups"] = []string{"admins"}
+	claims["email"] = "alice@example.com"
+	token := signer.mint(t, claims)
+
+	got, err := v.VerifyToken(context.Background(), token)
+	if err != nil {
+		t.Fatalf("VerifyToken: %v", err)
+	}
+	if got.Subject != "user-42" {
+		t.Errorf("subject: got %q want %q", got.Subject, "user-42")
+	}
+	if len(got.Audience) != 1 || got.Audience[0] != testClient {
+		t.Errorf("audience: got %v want [%s]", got.Audience, testClient)
+	}
+	if got.Issuer != IssuerPrefix+testRegion+".amazonaws.com/"+testPool {
+		t.Errorf("issuer: got %q", got.Issuer)
+	}
+	if v, ok := got.Extra["token_use"].(string); !ok || v != TokenUseID {
+		t.Errorf("token_use not surfaced: %v", got.Extra["token_use"])
+	}
+	if v, ok := got.Extra["cognito:username"].(string); !ok || v != "alice" {
+		t.Errorf("cognito:username not surfaced: %v", got.Extra["cognito:username"])
+	}
+	if _, ok := got.Extra["cognito:groups"]; !ok {
+		t.Errorf("cognito:groups not surfaced: %v", got.Extra)
+	}
+}
+
+func TestVerify_ValidAccessToken_Success(t *testing.T) {
+	signer := newTestSigner(t, "kid-1")
+	jwks := newJWKSServer(t, signer)
+	v := newVerifier(t, testRegion, testPool, jwks, WithAppClientID(testClient))
+
+	claims := accessClaims(testRegion, testPool, testClient, "user-99")
+	claims["scope"] = "aws.cognito.signin.user.admin"
+	token := signer.mint(t, claims)
+
+	got, err := v.VerifyToken(context.Background(), token)
+	if err != nil {
+		t.Fatalf("VerifyToken: %v", err)
+	}
+	if got.Subject != "user-99" {
+		t.Errorf("subject: got %q want %q", got.Subject, "user-99")
+	}
+	if v, ok := got.Extra["client_id"].(string); !ok || v != testClient {
+		t.Errorf("client_id not surfaced: %v", got.Extra["client_id"])
+	}
+	if v, ok := got.Extra["token_use"].(string); !ok || v != TokenUseAccess {
+		t.Errorf("token_use: got %v", got.Extra["token_use"])
+	}
+}
+
+func TestVerify_BadSignature_Fails(t *testing.T) {
+	signer := newTestSigner(t, "kid-1")
+	jwks := newJWKSServer(t, signer)
+	v := newVerifier(t, testRegion, testPool, jwks)
+
+	token := signer.mint(t, idClaims(testRegion, testPool, testClient, "user-42"))
+	// Replace the last four base64url chars of the signature so the
+	// decode succeeds but the resulting bytes don't verify.
+	tampered := token[:len(token)-4] + "AAAA"
+
+	if _, err := v.VerifyToken(context.Background(), tampered); !errors.Is(err, auth.ErrInvalidSig) {
+		t.Fatalf("VerifyToken: got %v, want ErrInvalidSig", err)
+	}
+}
+
+func TestVerify_WrongIssuer_Fails(t *testing.T) {
+	signer := newTestSigner(t, "kid-1")
+	jwks := newJWKSServer(t, signer)
+	v := newVerifier(t, testRegion, testPool, jwks)
+
+	claims := idClaims(testRegion, testPool, testClient, "user-42")
+	claims["iss"] = IssuerPrefix + testRegion + ".amazonaws.com/us-east-1_OtherPool"
+	token := signer.mint(t, claims)
+
+	if _, err := v.VerifyToken(context.Background(), token); !errors.Is(err, auth.ErrIssuerMismatch) {
+		t.Fatalf("VerifyToken: got %v, want ErrIssuerMismatch", err)
+	}
+}
+
+func TestVerify_WrongAudience_Fails(t *testing.T) {
+	signer := newTestSigner(t, "kid-1")
+	jwks := newJWKSServer(t, signer)
+	v := newVerifier(t, testRegion, testPool, jwks, WithAppClientID(testClient))
+
+	// ID token whose aud does not match the pinned app client id.
+	claims := idClaims(testRegion, testPool, "some-other-client", "user-42")
+	token := signer.mint(t, claims)
+
+	if _, err := v.VerifyToken(context.Background(), token); !errors.Is(err, auth.ErrAudMismatch) {
+		t.Fatalf("id-token wrong aud: got %v, want ErrAudMismatch", err)
+	}
+
+	// Access token whose client_id does not match either.
+	claims2 := accessClaims(testRegion, testPool, "some-other-client", "user-42")
+	token2 := signer.mint(t, claims2)
+	if _, err := v.VerifyToken(context.Background(), token2); !errors.Is(err, auth.ErrAudMismatch) {
+		t.Fatalf("access-token wrong client_id: got %v, want ErrAudMismatch", err)
+	}
+}
+
+func TestVerify_ExpiredToken_Fails(t *testing.T) {
+	signer := newTestSigner(t, "kid-1")
+	jwks := newJWKSServer(t, signer)
+	v := newVerifier(t, testRegion, testPool, jwks, WithLeeway(0))
+
+	claims := idClaims(testRegion, testPool, testClient, "user-42")
+	claims["iat"] = time.Now().Add(-2 * time.Hour).Unix()
+	claims["exp"] = time.Now().Add(-time.Hour).Unix()
+	token := signer.mint(t, claims)
+
+	if _, err := v.VerifyToken(context.Background(), token); !errors.Is(err, auth.ErrExpired) {
+		t.Fatalf("VerifyToken: got %v, want ErrExpired", err)
+	}
+}
+
+func TestVerify_UnknownKid_RefreshesJWKS(t *testing.T) {
+	signerOld := newTestSigner(t, "kid-old")
+	signerNew := newTestSigner(t, "kid-new")
+	// Start with only the old kid published.
+	jwks := newJWKSServer(t, signerOld)
+	v := newVerifier(t, testRegion, testPool, jwks)
+
+	// Prime the cache with a valid old-kid token.
+	if _, err := v.VerifyToken(context.Background(), signerOld.mint(t, idClaims(testRegion, testPool, testClient, "user-old"))); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+	primeHits := jwks.hits.Load()
+	if primeHits == 0 {
+		t.Fatalf("expected at least one JWKS fetch during priming")
+	}
+
+	// Rotate the JWKS to publish the new kid alongside the old one.
+	jwks.setSigners(signerOld, signerNew)
+
+	claims := idClaims(testRegion, testPool, testClient, "user-new")
+	token := signerNew.mint(t, claims)
+	got, err := v.VerifyToken(context.Background(), token)
+	if err != nil {
+		t.Fatalf("VerifyToken (rotate): %v", err)
+	}
+	if got.Subject != "user-new" {
+		t.Errorf("subject: got %q", got.Subject)
+	}
+	if jwks.hits.Load() <= primeHits {
+		t.Errorf("expected another JWKS fetch on unknown kid; hits stayed at %d", jwks.hits.Load())
+	}
+}
+
+func TestVerify_WrongTokenUse_Fails(t *testing.T) {
+	signer := newTestSigner(t, "kid-1")
+	jwks := newJWKSServer(t, signer)
+	// Only accept id tokens; access tokens must be rejected.
+	v := newVerifier(t, testRegion, testPool, jwks, WithTokenUse(TokenUseID))
+
+	claims := accessClaims(testRegion, testPool, testClient, "user-42")
+	token := signer.mint(t, claims)
+
+	_, err := v.VerifyToken(context.Background(), token)
+	if !errors.Is(err, auth.ErrInvalidToken) {
+		t.Fatalf("VerifyToken: got %v, want ErrInvalidToken", err)
+	}
+}
+
+func TestVerify_EmptySubject_Fails(t *testing.T) {
+	signer := newTestSigner(t, "kid-1")
+	jwks := newJWKSServer(t, signer)
+	v := newVerifier(t, testRegion, testPool, jwks)
+
+	claims := idClaims(testRegion, testPool, testClient, "")
+	token := signer.mint(t, claims)
+
+	_, err := v.VerifyToken(context.Background(), token)
+	if !errors.Is(err, auth.ErrInvalidToken) {
+		t.Fatalf("VerifyToken: got %v, want ErrInvalidToken", err)
+	}
+}
+
+func TestNewVerifier_RequiresRegionAndPool(t *testing.T) {
+	if _, err := NewVerifier("", "pool"); err == nil {
+		t.Fatal("expected error for empty region")
+	}
+	if _, err := NewVerifier("us-east-1", ""); err == nil {
+		t.Fatal("expected error for empty userPoolID")
+	}
+}
+
+func TestVerifier_Alg(t *testing.T) {
+	v, err := NewVerifier(testRegion, testPool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.Alg() != auth.AlgRS256 {
+		t.Errorf("Alg: got %q", v.Alg())
+	}
+}
+
+// Compile-time assertion: *Verifier satisfies auth.Verifier.
+var _ auth.Verifier = (*Verifier)(nil)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.27
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.26
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.54.2
+	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.59.2
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.104.2
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.42.5
 	github.com/aws/aws-sdk-go-v2/service/sns v1.40.3
@@ -25,6 +26,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.31 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.23 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.12.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.30 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.31 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,10 +18,14 @@ github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.31 h1:3GUprIsfmGcC5SACIyB0e7E0BM1
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.31/go.mod h1:7PuV1yl5e2xnUbm+RqvVg5i2iBM8EyijZNoI9wsOoOc=
 github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.54.2 h1:qmKlhMqcFouMkrntKDOZ93vDQLBAoVCVVNMo5sJmq8o=
 github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.54.2/go.mod h1:RRUdkfdYMMT5wzMXS7pZ6JvsrW1e9XqJgKQq2ie3rIk=
+github.com/aws/aws-sdk-go-v2/service/dynamodb v1.59.2 h1:Rk2vMAylCpfUapcjnDLApIyzBBqANEyTiN54VktI07Y=
+github.com/aws/aws-sdk-go-v2/service/dynamodb v1.59.2/go.mod h1:HnWoC3m6VmjUSg+kBL6OgQsXdyRAGzBYWb7B3J2f+JM=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.13 h1:mbRIur/BiHK6SKPjoBIXSE/hJ6g6JGRLuxQy1jGjlN4=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.13/go.mod h1:ITg9em2KbJx1s0y4aqRX5OYWG6HBZ5TVR//OdpEZ2CQ=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.23 h1:9Fjh6fi/U5JEStVZijmaMpUwE/gvBJj7x2B/PjbO9To=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.23/go.mod h1:iMoT2f1tClxrWAAnKCXjZQ6LOmfLrMG14wmnWpM+F14=
+github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.12.7 h1:uqsKxr7kJp9DXVj2m8KbVeZcYMuwsNEwvoVrYl2Vpf8=
+github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.12.7/go.mod h1:Js/P8Zbwe1mRejnD+OpFLyQiJ8ioQlo3GMAg7Dfxk7w=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.30 h1:/Z5jmNrKsSD7EmDjzAPsm/3L9IuOkzaynklJZ1qX7S4=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.30/go.mod h1:lEzEZnOosE7zi8Z6royW1cFJTD9fpab4Ul1SBrllewk=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.31 h1:uao4A3QZ5UmB326V6KF+qRpv9Tjz7IlnlnTbbANntlU=


### PR DESCRIPTION
## Description

Adds an AWS Cognito User Pool adapter for the `oss.nandlabs.io/golly/auth`
primitives, matching the layout already merged for `golly-gcp/auth/firebase`.

### Related Issue

Closes #177

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `auth/cognito/verifier.go` — JWKS-backed `*Verifier` implementing
  `auth.Verifier`. Fetches keys from
  `https://cognito-idp.<region>.amazonaws.com/<userPoolID>/.well-known/jwks.json`,
  parses the RSA `n`/`e` JWK fields, caches per-kid with a configurable
  TTL (default 1h) and refreshes on unknown-kid lookups so key rotation
  is handled transparently. `VerifyToken` enforces RS256, the Cognito
  issuer, `exp` / `iat` with configurable leeway and a non-empty `sub`.
  `token_use` distinguishes ID tokens (`aud == client id`) from access
  tokens (`client_id == client id`); both are accepted by default, and
  `WithTokenUse` narrows to one. `WithAppClientID` pins the app client
  id. Cognito-specific claims (`cognito:groups`, `cognito:username`,
  `token_use`, `client_id`) are surfaced via `Claims.Extra`.
- `auth/cognito/session.go` — `DynamoDBSessionStore` implementing
  `auth.SessionStore` on top of DynamoDB. Item schema: `id` (S, PK),
  `user_id` (S), `payload` (S, JSON) and `expires_at` (N, Unix
  seconds). The `expires_at` attribute is intended as the DynamoDB TTL
  attribute so operators get server-side pruning of expired sessions.
  `ListByUser` queries the `userID-index` GSI and, if that index is
  missing, returns an error wrapping `ErrNotSupported` alongside the
  verbatim DynamoDB `ValidationException` so operators can act on it.
- `auth/cognito/verifier_test.go` — httptest-hosted JWKS server + in-
  process RSA signer covering: valid ID token, valid access token, bad
  signature, wrong issuer, wrong audience / `client_id`, expired,
  unknown-kid JWKS refresh, `WithTokenUse` restriction, and empty
  subject.
- `auth/cognito/session_test.go` — in-memory `ddbAPI` mock covering the
  Put/Get/Delete round trip, missing-id Get, `ListByUser` via a mock
  query, the missing-GSI `ErrNotSupported` path, and payload/JSON /
  binary decode paths.
- `auth/cognito/doc.go` + `README.md` — package doc, 15-line quick-
  start, table schema, and the DynamoDB TTL guidance.
- `go.mod` / `go.sum` — adds `github.com/aws/aws-sdk-go-v2/service/dynamodb`
  (only new direct dep).

Scope is limited to the new `auth/cognito/` directory; no other
packages are touched.

## Testing

- [x] I have added/updated unit tests for my changes
- [x] All existing tests pass (`go test ./...`)
- [x] I have tested this locally

Validation on this branch:

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test -race -count=1 ./auth/cognito/` — 21 tests pass

### Test Output

```
$ go test -race -count=1 ./auth/cognito/
ok  	oss.nandlabs.io/golly-aws/auth/cognito	2.5s
```

## Checklist

- [x] My code follows the project's coding style and conventions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I agree my contribution may be redistributed under either the [Apache 2.0](../LICENSE-APACHE) or [MIT](../LICENSE-MIT) license (project is dual-licensed; see [License of Contributions](../CONTRIBUTING.md#license-of-contributions))

## Additional Context

The other contributors to this project agree to the inbound rules for all contributions made so far and provide their consent by approving this PR.