### PR TITLE
feat(authz/awsiam): AWS IAM authorizer with cached + live modes

### DIFF
--- a/authz/awsiam/README.md
+++ b/authz/awsiam/README.md
@@ -1,0 +1,130 @@
+# awsiam — AWS IAM authorizer for `golly/authz`
+
+`awsiam` adapts AWS IAM to the `oss.nandlabs.io/golly/authz.Policy`
+interface, so IAM policies bound to AWS users or roles can be used as
+the source of truth for `Can(principal, action, resource)` checks in a
+Golly app.
+
+## Why this package looks the way it does
+
+`authz.Policy.Can(p Principal, action string, resource any) bool` is
+deliberately context-free and returns a plain bool. That doesn't fit an
+AWS `iam:SimulatePrincipalPolicy` call, which needs a `context.Context`
+and can fail with a network error. This package offers two shapes:
+
+- **Cached evaluator (recommended)** — a background goroutine refreshes
+  an allowed-actions map on a configurable interval. `Can` reads from
+  the map. Freshness is bounded by the refresh interval; latency is
+  amortised across many `Can` calls.
+- **Live check via `IAMResource`** — pass an `IAMResource{Ctx, Arn}` as
+  the `resource any` argument. `Can` type-asserts, then makes a live
+  `iam:SimulatePrincipalPolicy` round-trip for that single action. No
+  cache is consulted or updated.
+
+## Usage
+
+```go
+import (
+    "context"
+    "time"
+
+    "github.com/aws/aws-sdk-go-v2/config"
+    "github.com/aws/aws-sdk-go-v2/service/iam"
+    "oss.nandlabs.io/golly/authz"
+    "oss.nandlabs.io/golly-aws/authz/awsiam"
+)
+
+func main() {
+    ctx := context.Background()
+
+    // 1. AWS IAM client — reuse across evaluators.
+    cfg, err := config.LoadDefaultConfig(ctx)
+    if err != nil { /* handle */ }
+    iamClient := iam.NewFromConfig(cfg)
+
+    principalArn := "arn:aws:iam::123456789012:role/svc"
+    bucketArn := "arn:aws:s3:::my-bucket"
+
+    // 2. Cached IAM evaluator, refreshed every minute.
+    eval := awsiam.NewCachedEvaluator(iamClient, principalArn, bucketArn,
+        []string{"s3:GetObject", "s3:ListBucket"},
+        time.Minute,
+        awsiam.WithExpectedMember(principalArn),
+    )
+    defer eval.Close()
+
+    // 3. Compose with any other Policy — here RBAC as the local fallback.
+    rbac := authz.NewRBAC()
+    rbac.AddRole("admin", "s3:GetObject")
+
+    policy := authz.Any(eval, rbac) // IAM says yes OR RBAC says yes
+
+    // 4. Cached lookup: no round-trip.
+    p := &myPrincipal{id: principalArn}
+    if policy.Can(p, "s3:GetObject", nil) {
+        // proceed
+    }
+
+    // 5. Live per-call check against a specific object ARN — bypasses
+    //    the cache and hits IAM synchronously.
+    live := awsiam.IAMResource{Ctx: ctx, Arn: "arn:aws:s3:::my-bucket/reports/2026.pdf"}
+    if eval.Can(p, "s3:GetObject", live) {
+        // proceed
+    }
+}
+```
+
+`myPrincipal` needs `Roles()`, `Capabilities()`, and either an
+`ID() string` accessor (picked up by the default extractor) or one
+injected with `awsiam.WithPrincipalMember(func(p authz.Principal) string { ... })`.
+`Arn()` and `Member()` accessors are also recognised by the default
+extractor.
+
+## Options
+
+| Option                        | Effect                                                                       |
+|-------------------------------|------------------------------------------------------------------------------|
+| `WithPrincipalMember(fn)`     | Override how a Principal is mapped to an IAM member string (its ARN).        |
+| `WithExpectedMember(arn)`     | Deny any Principal whose extracted member doesn't equal `arn`.               |
+| `WithInitialPermissions(m)`   | Seed the cache with a pre-computed `map[action]bool` before the first refresh.|
+
+## Behaviour
+
+- `Can(p, action, resource)`:
+  - If `WithExpectedMember` is set and the extracted principal member
+    doesn't match, returns `false` before any cache lookup or live call.
+  - If `resource` is `IAMResource{Ctx, Arn}` (or `*IAMResource`) and
+    `Arn` is non-empty, dispatches a live
+    `iam:SimulatePrincipalPolicy` for that single action and returns
+    `EvalDecision == "allowed"`. Errors map to `false`.
+  - Otherwise consults the cache: returns `cache[action]`. Actions not
+    in the cache return `false`.
+- The background loop calls `iam:SimulatePrincipalPolicy` every
+  `refresh` interval with `PolicySourceArn = principalArn`,
+  `ActionNames = actions`, `ResourceArns = [resource]`. On success the
+  cache map is atomically replaced. On error the previous cache is
+  preserved.
+- `Close` is safe to call multiple times and blocks until the loop
+  goroutine has exited.
+
+## IAM permission required
+
+The credentials the client is authenticated with need
+`iam:SimulatePrincipalPolicy` for the `PolicySourceArn` being
+simulated. See the
+[IAM API reference](https://docs.aws.amazon.com/IAM/latest/APIReference/API_SimulatePrincipalPolicy.html)
+for details.
+
+## Notes
+
+- `iam:SimulatePrincipalPolicy` evaluates policies attached to the
+  given `PolicySourceArn` (an IAM user, group, or role). It does **not**
+  evaluate policies of an arbitrary principal at call time —
+  `WithExpectedMember` makes that constraint explicit so a Principal
+  with a different identity is not silently granted the cached role's
+  permissions.
+- IAM permission boundaries, session policies, and SCPs are honoured by
+  the simulation.
+- The cache is invalidated only by `Refresh` (manual or the background
+  loop). Rotate the refresh interval to trade freshness for QPS against
+  IAM's throttling limits.

--- a/authz/awsiam/doc.go
+++ b/authz/awsiam/doc.go
@@ -1,0 +1,27 @@
+// Package awsiam adapts AWS IAM permission checks to the
+// oss.nandlabs.io/golly/authz.Policy interface.
+//
+// The upstream Policy interface has the signature
+//
+//	Can(p Principal, action string, resource any) bool
+//
+// which is context-free and returns a plain bool. That does not fit the
+// shape of an AWS IAM call (which needs a context.Context and can fail
+// with a network error). This package offers two workable shapes:
+//
+//   - A cached Evaluator that refreshes an allowed-actions map on a
+//     background goroutine. Can consults the cached map synchronously.
+//     Freshness is bounded by the configured refresh interval. This is
+//     the recommended production shape.
+//
+//   - An IAMResource envelope callers pass as the `resource any` argument
+//     when they want a live iam:SimulatePrincipalPolicy call instead of
+//     the cache. The context and the fully-qualified resource ARN ride
+//     along on the envelope so Can can type-assert them out.
+//
+// Under the hood the evaluator calls
+// iam.Client.SimulatePrincipalPolicy(ctx, {PolicySourceArn, ActionNames,
+// ResourceArns}). An EvalDecision of "allowed" maps to true; anything
+// else (explicitDeny, implicitDeny, or a transport error on the live
+// path) maps to false.
+package awsiam

--- a/authz/awsiam/evaluator.go
+++ b/authz/awsiam/evaluator.go
@@ -1,0 +1,341 @@
+package awsiam
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"oss.nandlabs.io/golly/authz"
+)
+
+// IAMCaller is the minimal surface the evaluator uses on an AWS IAM
+// client. The concrete *iam.Client from aws-sdk-go-v2 satisfies it
+// directly; tests inject a fake.
+type IAMCaller interface {
+	SimulatePrincipalPolicy(ctx context.Context, in *iam.SimulatePrincipalPolicyInput, opts ...func(*iam.Options)) (*iam.SimulatePrincipalPolicyOutput, error)
+}
+
+// PrincipalMemberFunc extracts an AWS IAM member string (typically an
+// IAM user or role ARN such as "arn:aws:iam::123456789012:role/svc")
+// from an authz.Principal. Callers supply one via WithPrincipalMember
+// when their Principal implementation doesn't expose an
+// ID()/Member()/Arn() accessor.
+type PrincipalMemberFunc func(p authz.Principal) string
+
+// IAMResource is passed as the `resource any` argument to Evaluator.Can
+// when the caller wants a live iam:SimulatePrincipalPolicy round-trip
+// instead of consulting the cached allowed-actions map. It carries the
+// context and the fully-qualified AWS resource ARN.
+//
+// This is a workaround for the fact that authz.Policy.Can does not take
+// a context.Context. Callers that don't need live checks can just pass
+// any value they like (including nil) as the `resource any` argument.
+type IAMResource struct {
+	// Ctx is the request context used for the live call. If nil,
+	// context.Background() is used.
+	Ctx context.Context
+	// Arn is the fully-qualified AWS resource ARN the action is
+	// evaluated against (e.g. "arn:aws:s3:::my-bucket/foo"). If
+	// empty, the evaluator's configured resource ARN is used.
+	Arn string
+}
+
+// Option customises an Evaluator at construction time.
+type Option func(*Evaluator)
+
+// WithPrincipalMember overrides the extractor used to derive an IAM
+// member string (the principal ARN) from an authz.Principal. The
+// default extractor tries interface{ ID() string }, then
+// interface{ Arn() string }, then interface{ Member() string } via
+// type-assertion and returns "" if none is present.
+func WithPrincipalMember(fn PrincipalMemberFunc) Option {
+	return func(e *Evaluator) {
+		if fn != nil {
+			e.extractor = fn
+		}
+	}
+}
+
+// WithExpectedMember restricts Can to grant only when the extracted
+// principal-member equals `member`. Use this when the evaluator has
+// been wired to a specific principal ARN and you want callers whose
+// Principal resolves to a different member to be denied without a
+// cache lookup or live call.
+func WithExpectedMember(member string) Option {
+	return func(e *Evaluator) { e.expected = member }
+}
+
+// WithInitialPermissions seeds the cache with a pre-computed
+// allowed-actions map before the first Refresh runs. Useful when the
+// process starts up with a known set of permissions and shouldn't have
+// to wait a full refresh interval before Can can answer.
+func WithInitialPermissions(perms map[string]bool) Option {
+	return func(e *Evaluator) {
+		if perms == nil {
+			return
+		}
+		next := make(map[string]bool, len(perms))
+		for k, v := range perms {
+			if k != "" {
+				next[k] = v
+			}
+		}
+		e.perms = next
+	}
+}
+
+// Evaluator implements authz.Policy by consulting an AWS IAM
+// allowed-actions map cached in memory. A background goroutine re-runs
+// iam:SimulatePrincipalPolicy every `refresh` interval to keep the map
+// current.
+//
+// Can also accepts an IAMResource / *IAMResource as its `resource any`
+// argument to force a live check that bypasses the cache — see
+// IAMResource for details.
+type Evaluator struct {
+	caller       IAMCaller
+	principalArn string
+	resource     string
+	actions      []string
+	refresh      time.Duration
+	extractor    PrincipalMemberFunc
+	expected     string
+
+	mu    sync.RWMutex
+	perms map[string]bool // action -> allowed for the configured principalArn
+
+	stopCh   chan struct{}
+	doneCh   chan struct{}
+	closedMu sync.Mutex
+	closed   bool
+}
+
+// NewCachedEvaluator wires the evaluator to a real *iam.Client. It is a
+// thin wrapper over NewCachedEvaluatorFromCaller for the common case.
+// principalArn is the ARN whose permissions we are caching. resource is
+// the target ARN the actions are simulated against. actions is the set
+// of IAM API actions to pre-fetch (e.g. "s3:GetObject"). Pass 0 (or a
+// negative value) for `refresh` to disable the background refresh
+// goroutine — the caller then invokes Refresh manually.
+func NewCachedEvaluator(client *iam.Client, principalArn, resource string, actions []string, refresh time.Duration, opts ...Option) *Evaluator {
+	return NewCachedEvaluatorFromCaller(client, principalArn, resource, actions, refresh, opts...)
+}
+
+// NewCachedEvaluatorFromCaller is the general constructor: any client
+// that satisfies IAMCaller can be plugged in. Tests use it to inject a
+// fake caller.
+func NewCachedEvaluatorFromCaller(caller IAMCaller, principalArn, resource string, actions []string, refresh time.Duration, opts ...Option) *Evaluator {
+	trimmed := make([]string, 0, len(actions))
+	seen := make(map[string]struct{}, len(actions))
+	for _, a := range actions {
+		if a == "" {
+			continue
+		}
+		if _, dup := seen[a]; dup {
+			continue
+		}
+		seen[a] = struct{}{}
+		trimmed = append(trimmed, a)
+	}
+	e := &Evaluator{
+		caller:       caller,
+		principalArn: principalArn,
+		resource:     resource,
+		actions:      trimmed,
+		refresh:      refresh,
+		extractor:    defaultPrincipalMember,
+		perms:        make(map[string]bool),
+		stopCh:       make(chan struct{}),
+		doneCh:       make(chan struct{}),
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(e)
+		}
+	}
+	if refresh > 0 {
+		go e.loop()
+	} else {
+		close(e.doneCh)
+	}
+	return e
+}
+
+// defaultPrincipalMember tries a couple of common accessor shapes
+// before giving up. Callers with a bespoke Principal type should inject
+// an extractor via WithPrincipalMember.
+func defaultPrincipalMember(p authz.Principal) string {
+	if p == nil {
+		return ""
+	}
+	if withID, ok := p.(interface{ ID() string }); ok {
+		return withID.ID()
+	}
+	if withArn, ok := p.(interface{ Arn() string }); ok {
+		return withArn.Arn()
+	}
+	if withMember, ok := p.(interface{ Member() string }); ok {
+		return withMember.Member()
+	}
+	return ""
+}
+
+func (e *Evaluator) loop() {
+	defer close(e.doneCh)
+	t := time.NewTicker(e.refresh)
+	defer t.Stop()
+	for {
+		select {
+		case <-e.stopCh:
+			return
+		case <-t.C:
+			ctx, cancel := context.WithTimeout(context.Background(), e.refresh)
+			_ = e.Refresh(ctx)
+			cancel()
+		}
+	}
+}
+
+// Refresh re-runs iam:SimulatePrincipalPolicy for the configured
+// principal, resource, and action set, and replaces the cached
+// allowed-actions map. Safe for concurrent use with Can. Returns
+// whatever error the underlying IAM call returned; the cache is left
+// untouched on error.
+func (e *Evaluator) Refresh(ctx context.Context) error {
+	if e == nil || e.caller == nil {
+		return errors.New("awsiam: evaluator has no caller")
+	}
+	if len(e.actions) == 0 {
+		return nil
+	}
+	in := &iam.SimulatePrincipalPolicyInput{
+		PolicySourceArn: aws.String(e.principalArn),
+		ActionNames:     append([]string(nil), e.actions...),
+	}
+	if e.resource != "" {
+		in.ResourceArns = []string{e.resource}
+	}
+	resp, err := e.caller.SimulatePrincipalPolicy(ctx, in)
+	if err != nil {
+		return fmt.Errorf("awsiam: SimulatePrincipalPolicy on %q: %w", e.resource, err)
+	}
+	next := make(map[string]bool, len(e.actions))
+	for _, a := range e.actions {
+		next[a] = false
+	}
+	for _, r := range resp.EvaluationResults {
+		if r.EvalActionName == nil {
+			continue
+		}
+		next[*r.EvalActionName] = r.EvalDecision == types.PolicyEvaluationDecisionTypeAllowed
+	}
+	e.mu.Lock()
+	e.perms = next
+	e.mu.Unlock()
+	return nil
+}
+
+// Can satisfies authz.Policy.
+//
+// If `resource` is an IAMResource or *IAMResource, Can bypasses the
+// cache and makes a live iam:SimulatePrincipalPolicy call using the
+// embedded context and ARN. Otherwise it consults the cached
+// allowed-actions map. Actions not present in the cache resolve to
+// false — the caller is expected to seed them via the actions slice
+// passed to NewCachedEvaluator or via WithInitialPermissions.
+func (e *Evaluator) Can(p authz.Principal, action string, resource any) bool {
+	if e == nil || action == "" {
+		return false
+	}
+	if !e.principalOK(p) {
+		return false
+	}
+	if live, arn, ctx, ok := extractIAMResource(resource); ok {
+		_ = live
+		// Empty ARN on the envelope means "no target resource to
+		// simulate against" — fall through to the cache rather than
+		// dispatch a malformed live call.
+		if arn != "" {
+			return e.liveCheck(ctx, arn, action)
+		}
+	}
+	e.mu.RLock()
+	allowed := e.perms[action]
+	e.mu.RUnlock()
+	return allowed
+}
+
+// principalOK enforces WithExpectedMember: when set, the extracted
+// principal-member must equal the expected ARN or the call is denied
+// before any cache lookup or live IAM call. When WithExpectedMember is
+// unset, no principal-gating happens — the cache reflects the
+// configured principalArn, not the calling identity.
+func (e *Evaluator) principalOK(p authz.Principal) bool {
+	if e.expected == "" {
+		return true
+	}
+	return e.extractor(p) == e.expected
+}
+
+func (e *Evaluator) liveCheck(ctx context.Context, arn, action string) bool {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	in := &iam.SimulatePrincipalPolicyInput{
+		PolicySourceArn: aws.String(e.principalArn),
+		ActionNames:     []string{action},
+		ResourceArns:    []string{arn},
+	}
+	resp, err := e.caller.SimulatePrincipalPolicy(ctx, in)
+	if err != nil {
+		return false
+	}
+	for _, r := range resp.EvaluationResults {
+		if r.EvalActionName == nil || *r.EvalActionName != action {
+			continue
+		}
+		if r.EvalDecision == types.PolicyEvaluationDecisionTypeAllowed {
+			return true
+		}
+	}
+	return false
+}
+
+// extractIAMResource unwraps IAMResource / *IAMResource from the any.
+// Returns (present, arn, ctx, ok).
+func extractIAMResource(resource any) (IAMResource, string, context.Context, bool) {
+	switch r := resource.(type) {
+	case IAMResource:
+		return r, r.Arn, r.Ctx, true
+	case *IAMResource:
+		if r == nil {
+			return IAMResource{}, "", nil, false
+		}
+		return *r, r.Arn, r.Ctx, true
+	}
+	return IAMResource{}, "", nil, false
+}
+
+// Close stops the background refresh goroutine. Safe to call multiple
+// times. Returns nil — the error return exists for symmetry with
+// io.Closer.
+func (e *Evaluator) Close() error {
+	if e == nil {
+		return nil
+	}
+	e.closedMu.Lock()
+	if e.closed {
+		e.closedMu.Unlock()
+		return nil
+	}
+	e.closed = true
+	close(e.stopCh)
+	e.closedMu.Unlock()
+	<-e.doneCh
+	return nil
+}

--- a/authz/awsiam/evaluator_test.go
+++ b/authz/awsiam/evaluator_test.go
@@ -98,16 +98,6 @@ func (f *fakeCaller) callCount() int {
 	return f.calls
 }
 
-func (f *fakeCaller) lastActions() []string {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	if f.lastReq == nil {
-		return nil
-	}
-	out := append([]string(nil), f.lastReq.ActionNames...)
-	return out
-}
-
 const (
 	testPrincipalArn = "arn:aws:iam::123456789012:role/svc"
 	testBucketArn    = "arn:aws:s3:::my-bucket"

--- a/authz/awsiam/evaluator_test.go
+++ b/authz/awsiam/evaluator_test.go
@@ -1,0 +1,343 @@
+package awsiam
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"oss.nandlabs.io/golly/authz"
+)
+
+// principalWithID is a test Principal that also exposes ID() so the
+// default extractor picks it up via type-assertion.
+type principalWithID struct {
+	id    string
+	roles []string
+	caps  []string
+}
+
+func (p *principalWithID) ID() string             { return p.id }
+func (p *principalWithID) Roles() []string        { return p.roles }
+func (p *principalWithID) Capabilities() []string { return p.caps }
+
+// fakeCaller records every SimulatePrincipalPolicy call and returns an
+// evaluation result for each action driven by the `granted` map. Tests
+// mutate granted / err between refreshes.
+type fakeCaller struct {
+	mu       sync.Mutex
+	granted  map[string]bool // action -> allowed on this resource
+	calls    int
+	lastReq  *iam.SimulatePrincipalPolicyInput
+	err      error
+	callHook func()
+}
+
+func newFakeCaller(granted ...string) *fakeCaller {
+	m := make(map[string]bool, len(granted))
+	for _, g := range granted {
+		m[g] = true
+	}
+	return &fakeCaller{granted: m}
+}
+
+func (f *fakeCaller) SimulatePrincipalPolicy(_ context.Context, in *iam.SimulatePrincipalPolicyInput, _ ...func(*iam.Options)) (*iam.SimulatePrincipalPolicyOutput, error) {
+	f.mu.Lock()
+	f.calls++
+	f.lastReq = in
+	hook := f.callHook
+	err := f.err
+	grantedCopy := make(map[string]bool, len(f.granted))
+	for k, v := range f.granted {
+		grantedCopy[k] = v
+	}
+	f.mu.Unlock()
+	if hook != nil {
+		hook()
+	}
+	if err != nil {
+		return nil, err
+	}
+	out := &iam.SimulatePrincipalPolicyOutput{}
+	for _, a := range in.ActionNames {
+		action := a
+		decision := types.PolicyEvaluationDecisionTypeImplicitDeny
+		if grantedCopy[action] {
+			decision = types.PolicyEvaluationDecisionTypeAllowed
+		}
+		out.EvaluationResults = append(out.EvaluationResults, types.EvaluationResult{
+			EvalActionName: aws.String(action),
+			EvalDecision:   decision,
+		})
+	}
+	return out, nil
+}
+
+func (f *fakeCaller) setGranted(perms ...string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.granted = map[string]bool{}
+	for _, p := range perms {
+		f.granted[p] = true
+	}
+}
+
+func (f *fakeCaller) setErr(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.err = err
+}
+
+func (f *fakeCaller) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+func (f *fakeCaller) lastActions() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.lastReq == nil {
+		return nil
+	}
+	out := append([]string(nil), f.lastReq.ActionNames...)
+	return out
+}
+
+const (
+	testPrincipalArn = "arn:aws:iam::123456789012:role/svc"
+	testBucketArn    = "arn:aws:s3:::my-bucket"
+)
+
+func TestCachedEvaluator_HitsCacheBetweenRefresh(t *testing.T) {
+	t.Parallel()
+	fc := newFakeCaller("s3:GetObject")
+	// refresh=0 disables the background loop; we drive Refresh manually.
+	e := NewCachedEvaluatorFromCaller(fc, testPrincipalArn, testBucketArn,
+		[]string{"s3:GetObject"}, 0)
+	defer func() { _ = e.Close() }()
+
+	if err := e.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if got := fc.callCount(); got != 1 {
+		t.Fatalf("expected 1 call after Refresh, got %d", got)
+	}
+
+	p := &principalWithID{id: testPrincipalArn}
+	for i := 0; i < 5; i++ {
+		if !e.Can(p, "s3:GetObject", nil) {
+			t.Fatalf("Can #%d: expected true from cache", i)
+		}
+	}
+	if got := fc.callCount(); got != 1 {
+		t.Fatalf("expected only cache hits, got %d additional calls", got-1)
+	}
+}
+
+func TestCachedEvaluator_RefreshUpdatesCache(t *testing.T) {
+	t.Parallel()
+	fc := newFakeCaller("s3:GetObject")
+	e := NewCachedEvaluatorFromCaller(fc, testPrincipalArn, testBucketArn,
+		[]string{"s3:GetObject"}, 0)
+	defer func() { _ = e.Close() }()
+
+	if err := e.Refresh(context.Background()); err != nil {
+		t.Fatalf("first Refresh: %v", err)
+	}
+
+	p := &principalWithID{id: testPrincipalArn}
+	if !e.Can(p, "s3:GetObject", nil) {
+		t.Fatal("Can before revoke: want true")
+	}
+
+	// IAM revokes the permission; next Refresh should reflect that.
+	fc.setGranted()
+	if err := e.Refresh(context.Background()); err != nil {
+		t.Fatalf("second Refresh: %v", err)
+	}
+	if e.Can(p, "s3:GetObject", nil) {
+		t.Fatal("Can after revoke: want false")
+	}
+
+	// Re-grant; cache flips back after another Refresh.
+	fc.setGranted("s3:GetObject")
+	if err := e.Refresh(context.Background()); err != nil {
+		t.Fatalf("third Refresh: %v", err)
+	}
+	if !e.Can(p, "s3:GetObject", nil) {
+		t.Fatal("Can after re-grant: want true")
+	}
+}
+
+func TestCachedEvaluator_MissingPermission_ReturnsFalse(t *testing.T) {
+	t.Parallel()
+	fc := newFakeCaller("s3:GetObject") // ListBucket is NOT granted
+	e := NewCachedEvaluatorFromCaller(fc, testPrincipalArn, testBucketArn,
+		[]string{"s3:GetObject", "s3:ListBucket"}, 0)
+	defer func() { _ = e.Close() }()
+
+	if err := e.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	p := &principalWithID{id: testPrincipalArn}
+	if !e.Can(p, "s3:GetObject", nil) {
+		t.Fatal("granted action: want true")
+	}
+	if e.Can(p, "s3:ListBucket", nil) {
+		t.Fatal("ungranted action: want false")
+	}
+	if e.Can(p, "s3:DeleteObject", nil) {
+		t.Fatal("action not in configured set: want false (uncached => deny)")
+	}
+}
+
+func TestCachedEvaluator_UnknownPrincipal_ReturnsFalse(t *testing.T) {
+	t.Parallel()
+	fc := newFakeCaller("s3:GetObject")
+	// Pin the evaluator to a specific principal ARN so mismatches are denied.
+	e := NewCachedEvaluatorFromCaller(fc, testPrincipalArn, testBucketArn,
+		[]string{"s3:GetObject"}, 0,
+		WithExpectedMember(testPrincipalArn))
+	defer func() { _ = e.Close() }()
+	if err := e.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	// A principal whose ID doesn't match the expected ARN is denied.
+	stranger := &principalWithID{id: "arn:aws:iam::123456789012:role/other"}
+	if e.Can(stranger, "s3:GetObject", nil) {
+		t.Fatal("wrong-member principal: want false")
+	}
+	// authz.BasicPrincipal has no ID accessor so extractor returns ""
+	// which cannot equal the expected ARN — also denied.
+	unknown := &authz.BasicPrincipal{RoleList: []string{"viewer"}}
+	if e.Can(unknown, "s3:GetObject", nil) {
+		t.Fatal("no-ID principal against expected member: want false")
+	}
+	// The matching principal is granted.
+	svc := &principalWithID{id: testPrincipalArn}
+	if !e.Can(svc, "s3:GetObject", nil) {
+		t.Fatal("expected member: want true")
+	}
+}
+
+func TestCachedEvaluator_BackgroundLoop_RefreshesOnInterval(t *testing.T) {
+	t.Parallel()
+	fc := newFakeCaller("s3:GetObject")
+	e := NewCachedEvaluatorFromCaller(fc, testPrincipalArn, testBucketArn,
+		[]string{"s3:GetObject"}, 20*time.Millisecond)
+	defer func() { _ = e.Close() }()
+
+	// Wait for at least two background refreshes so we know the ticker
+	// is actually looping and not just firing once.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if fc.callCount() >= 2 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := fc.callCount(); got < 2 {
+		t.Fatalf("background loop should refresh at least twice: got %d", got)
+	}
+	p := &principalWithID{id: testPrincipalArn}
+	if !e.Can(p, "s3:GetObject", nil) {
+		t.Fatal("after background refresh: want true")
+	}
+}
+
+func TestCachedEvaluator_RefreshError_PreservesCache(t *testing.T) {
+	t.Parallel()
+	fc := newFakeCaller("s3:GetObject")
+	e := NewCachedEvaluatorFromCaller(fc, testPrincipalArn, testBucketArn,
+		[]string{"s3:GetObject"}, 0)
+	defer func() { _ = e.Close() }()
+
+	if err := e.Refresh(context.Background()); err != nil {
+		t.Fatalf("first Refresh: %v", err)
+	}
+	p := &principalWithID{id: testPrincipalArn}
+	if !e.Can(p, "s3:GetObject", nil) {
+		t.Fatal("pre-error: want true")
+	}
+	// IAM now fails; the cache from the previous successful Refresh
+	// must not be clobbered.
+	fc.setErr(errors.New("boom"))
+	if err := e.Refresh(context.Background()); err == nil {
+		t.Fatal("Refresh with err: want error")
+	}
+	if !e.Can(p, "s3:GetObject", nil) {
+		t.Fatal("post-error: cache should still say true")
+	}
+}
+
+func TestCachedEvaluator_Close_Idempotent(t *testing.T) {
+	t.Parallel()
+	fc := newFakeCaller()
+	e := NewCachedEvaluatorFromCaller(fc, testPrincipalArn, testBucketArn,
+		[]string{"s3:GetObject"}, 20*time.Millisecond)
+	if err := e.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := e.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}
+
+func TestCachedEvaluator_InitialPermissions_SeedsCache(t *testing.T) {
+	t.Parallel()
+	// No Refresh has been driven and the fake caller is not consulted,
+	// but Can still resolves from the seeded cache.
+	fc := newFakeCaller()
+	e := NewCachedEvaluatorFromCaller(fc, testPrincipalArn, testBucketArn,
+		[]string{"s3:GetObject", "s3:PutObject"}, 0,
+		WithInitialPermissions(map[string]bool{
+			"s3:GetObject": true,
+			"s3:PutObject": false,
+		}))
+	defer func() { _ = e.Close() }()
+
+	p := &principalWithID{id: testPrincipalArn}
+	if !e.Can(p, "s3:GetObject", nil) {
+		t.Fatal("seeded allow: want true")
+	}
+	if e.Can(p, "s3:PutObject", nil) {
+		t.Fatal("seeded deny: want false")
+	}
+	if got := fc.callCount(); got != 0 {
+		t.Fatalf("expected no IAM calls, got %d", got)
+	}
+}
+
+func TestCachedEvaluator_Refresh_RequestShape(t *testing.T) {
+	t.Parallel()
+	fc := newFakeCaller("s3:GetObject")
+	actions := []string{"s3:GetObject", "s3:ListBucket"}
+	e := NewCachedEvaluatorFromCaller(fc, testPrincipalArn, testBucketArn, actions, 0)
+	defer func() { _ = e.Close() }()
+
+	if err := e.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	fc.mu.Lock()
+	got := fc.lastReq
+	fc.mu.Unlock()
+	if got == nil {
+		t.Fatal("no request recorded")
+	}
+	if got.PolicySourceArn == nil || *got.PolicySourceArn != testPrincipalArn {
+		t.Fatalf("PolicySourceArn: got %v, want %q", got.PolicySourceArn, testPrincipalArn)
+	}
+	if len(got.ResourceArns) != 1 || got.ResourceArns[0] != testBucketArn {
+		t.Fatalf("ResourceArns: got %v, want [%q]", got.ResourceArns, testBucketArn)
+	}
+	if len(got.ActionNames) != 2 {
+		t.Fatalf("ActionNames: got %v", got.ActionNames)
+	}
+}

--- a/authz/awsiam/iam_resource_test.go
+++ b/authz/awsiam/iam_resource_test.go
@@ -1,0 +1,139 @@
+package awsiam
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCan_IAMResource_LiveCall_Granted(t *testing.T) {
+	t.Parallel()
+	fc := newFakeCaller("s3:GetObject")
+	// No actions configured — the live path must not touch the cache.
+	e := NewCachedEvaluatorFromCaller(fc, testPrincipalArn, "unused", nil, 0)
+	defer func() { _ = e.Close() }()
+
+	p := &principalWithID{id: testPrincipalArn}
+	res := IAMResource{
+		Ctx: context.Background(),
+		Arn: "arn:aws:s3:::photos/foo.jpg",
+	}
+	if !e.Can(p, "s3:GetObject", res) {
+		t.Fatal("live check granted action: want true")
+	}
+	if got := fc.callCount(); got != 1 {
+		t.Fatalf("expected exactly 1 live call, got %d", got)
+	}
+	// The request must carry the IAMResource.Arn, not the evaluator's
+	// configured resource.
+	fc.mu.Lock()
+	got := fc.lastReq
+	fc.mu.Unlock()
+	if got == nil {
+		t.Fatal("no request recorded")
+	}
+	if len(got.ResourceArns) != 1 || got.ResourceArns[0] != "arn:aws:s3:::photos/foo.jpg" {
+		t.Fatalf("ResourceArns: want [%q], got %v", "arn:aws:s3:::photos/foo.jpg", got.ResourceArns)
+	}
+	if len(got.ActionNames) != 1 || got.ActionNames[0] != "s3:GetObject" {
+		t.Fatalf("ActionNames: want [s3:GetObject], got %v", got.ActionNames)
+	}
+}
+
+func TestCan_IAMResource_LiveCall_Denied(t *testing.T) {
+	t.Parallel()
+	fc := newFakeCaller() // nothing granted
+	e := NewCachedEvaluatorFromCaller(fc, testPrincipalArn, testBucketArn, nil, 0)
+	defer func() { _ = e.Close() }()
+
+	p := &principalWithID{id: testPrincipalArn}
+	res := &IAMResource{
+		Ctx: context.Background(),
+		Arn: "arn:aws:s3:::photos/foo.jpg",
+	}
+	if e.Can(p, "s3:DeleteObject", res) {
+		t.Fatal("live check ungranted action: want false")
+	}
+}
+
+func TestCan_IAMResource_NilCtx_UsesBackground(t *testing.T) {
+	t.Parallel()
+	fc := newFakeCaller("s3:GetObject")
+	e := NewCachedEvaluatorFromCaller(fc, testPrincipalArn, testBucketArn, nil, 0)
+	defer func() { _ = e.Close() }()
+
+	p := &principalWithID{id: testPrincipalArn}
+	// Ctx is nil — must not panic; evaluator falls back to
+	// context.Background().
+	res := IAMResource{Arn: "arn:aws:s3:::photos/foo.jpg"}
+	if !e.Can(p, "s3:GetObject", res) {
+		t.Fatal("nil ctx live path: want true")
+	}
+	if got := fc.callCount(); got != 1 {
+		t.Fatalf("expected 1 live call, got %d", got)
+	}
+}
+
+func TestCan_IAMResource_EmptyArn_FallsThroughToCache(t *testing.T) {
+	t.Parallel()
+	// The cache has s3:GetObject seeded; the live path must NOT be
+	// invoked when IAMResource.Arn is empty — instead Can consults the
+	// cache and returns its answer.
+	fc := newFakeCaller() // nothing granted live
+	e := NewCachedEvaluatorFromCaller(fc, testPrincipalArn, testBucketArn,
+		[]string{"s3:GetObject"}, 0,
+		WithInitialPermissions(map[string]bool{"s3:GetObject": true}))
+	defer func() { _ = e.Close() }()
+
+	p := &principalWithID{id: testPrincipalArn}
+	res := IAMResource{Ctx: context.Background()} // no Arn
+	if !e.Can(p, "s3:GetObject", res) {
+		t.Fatal("empty Arn: expected cache answer (true)")
+	}
+	if got := fc.callCount(); got != 0 {
+		t.Fatalf("expected zero live calls when Arn is empty, got %d", got)
+	}
+	// And an action absent from the cache is denied without a live call.
+	if e.Can(p, "s3:PutObject", res) {
+		t.Fatal("empty Arn, uncached action: want false")
+	}
+	if got := fc.callCount(); got != 0 {
+		t.Fatalf("expected zero live calls, got %d", got)
+	}
+}
+
+func TestCan_IAMResource_ExpectedMemberMismatch_ShortCircuits(t *testing.T) {
+	t.Parallel()
+	fc := newFakeCaller("s3:GetObject")
+	e := NewCachedEvaluatorFromCaller(fc, testPrincipalArn, testBucketArn, nil, 0,
+		WithExpectedMember(testPrincipalArn))
+	defer func() { _ = e.Close() }()
+
+	stranger := &principalWithID{id: "arn:aws:iam::123456789012:role/other"}
+	res := IAMResource{Ctx: context.Background(), Arn: "arn:aws:s3:::photos/foo.jpg"}
+	if e.Can(stranger, "s3:GetObject", res) {
+		t.Fatal("expected-member mismatch on live path: want false")
+	}
+	if got := fc.callCount(); got != 0 {
+		t.Fatalf("expected zero live calls for mismatched principal, got %d", got)
+	}
+}
+
+func TestCan_IAMResource_PointerNil_TreatedAsPlainResource(t *testing.T) {
+	t.Parallel()
+	// A nil *IAMResource must not be dereferenced. Since it's not a
+	// recognisable IAMResource envelope, Can falls through to the cache.
+	fc := newFakeCaller()
+	e := NewCachedEvaluatorFromCaller(fc, testPrincipalArn, testBucketArn,
+		[]string{"s3:GetObject"}, 0,
+		WithInitialPermissions(map[string]bool{"s3:GetObject": true}))
+	defer func() { _ = e.Close() }()
+
+	p := &principalWithID{id: testPrincipalArn}
+	var nilRes *IAMResource
+	if !e.Can(p, "s3:GetObject", nilRes) {
+		t.Fatal("nil *IAMResource: expected cache answer (true)")
+	}
+	if got := fc.callCount(); got != 0 {
+		t.Fatalf("expected zero live calls, got %d", got)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.26
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.54.2
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.59.2
+	github.com/aws/aws-sdk-go-v2/service/iam v1.54.7
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.104.2
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.42.5
 	github.com/aws/aws-sdk-go-v2/service/sns v1.40.3

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.54.2 h1:qmKlhMqcFouMkrntK
 github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.54.2/go.mod h1:RRUdkfdYMMT5wzMXS7pZ6JvsrW1e9XqJgKQq2ie3rIk=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.59.2 h1:Rk2vMAylCpfUapcjnDLApIyzBBqANEyTiN54VktI07Y=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.59.2/go.mod h1:HnWoC3m6VmjUSg+kBL6OgQsXdyRAGzBYWb7B3J2f+JM=
+github.com/aws/aws-sdk-go-v2/service/iam v1.54.7 h1:undHpuVUg25wS2CpeXNqVjIcJComV2RE5AZ7mJGth2U=
+github.com/aws/aws-sdk-go-v2/service/iam v1.54.7/go.mod h1:5H/UUroHvcKm6l2qaqh3CMM6R9K91ls8Y8rVX6cG3ts=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.13 h1:mbRIur/BiHK6SKPjoBIXSE/hJ6g6JGRLuxQy1jGjlN4=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.13/go.mod h1:ITg9em2KbJx1s0y4aqRX5OYWG6HBZ5TVR//OdpEZ2CQ=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.23 h1:9Fjh6fi/U5JEStVZijmaMpUwE/gvBJj7x2B/PjbO9To=


### PR DESCRIPTION
## Description

Adds a new `authz/awsiam` package that adapts AWS IAM to the
`oss.nandlabs.io/golly/authz.Policy` interface, so IAM policies bound
to AWS users or roles can drive `Can(principal, action, resource)`
decisions in a Golly app.

The upstream `Policy.Can(p Principal, action string, resource any) bool`
is context-free and returns a plain `bool`, which does not fit an
`iam:SimulatePrincipalPolicy` call (needs a `context.Context` and can
fail with a network error). This package ships two workable shapes:

- **Cached evaluator (recommended).** A background goroutine calls
  `iam:SimulatePrincipalPolicy` every `refresh` interval for a configured
  principal ARN, resource ARN, and action set, and atomically replaces
  an in-memory `map[action]bool`. `Can` consults the map synchronously —
  freshness is bounded by the refresh interval, latency is amortised.
  On refresh error the previous cache is preserved.

- **Live check via `IAMResource{Ctx, Arn}`.** Callers pass this
  envelope as the `resource any` argument to `Can` when they want a
  live check. The evaluator type-asserts, extracts the embedded ctx
  and ARN, and dispatches a single-action `SimulatePrincipalPolicy`
  call. This is the ctx-less `Policy` interface workaround: the
  caller smuggles the context through the resource slot rather than
  the package inventing a parallel interface.

### Related Issue

Closes #178

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- New package `authz/awsiam` with:
  - `Evaluator` implementing `authz.Policy`.
  - `NewCachedEvaluator(*iam.Client, principalArn, resource, actions, refresh, opts...)` and
    `NewCachedEvaluatorFromCaller(IAMCaller, ...)` for injecting fakes.
  - `IAMCaller` interface — the minimal surface (`SimulatePrincipalPolicy`) so real `*iam.Client` and test doubles interchange freely.
  - `IAMResource{Ctx, Arn}` live-check envelope.
  - Options: `WithPrincipalMember`, `WithExpectedMember`, `WithInitialPermissions(map[string]bool)`.
  - `Refresh(ctx)` (manual or background loop) and idempotent `Close`.
- `doc.go`, `README.md` with usage examples for both cached and live modes.
- Adds `github.com/aws/aws-sdk-go-v2/service/iam` as a direct dependency.

## Testing

- [x] I have added/updated unit tests for my changes
- [x] All existing tests pass (`go test ./...`)
- [x] I have tested this locally

### Test Output

```
$ go build ./...
$ go vet ./...
$ go test -race -count=1 ./authz/awsiam/
ok      oss.nandlabs.io/golly-aws/authz/awsiam  2.063s
```

Test cases (fake `IAMCaller`, no live AWS credentials required):

- `TestCachedEvaluator_HitsCacheBetweenRefresh`
- `TestCachedEvaluator_RefreshUpdatesCache`
- `TestCachedEvaluator_MissingPermission_ReturnsFalse`
- `TestCachedEvaluator_UnknownPrincipal_ReturnsFalse`
- `TestCachedEvaluator_BackgroundLoop_RefreshesOnInterval`
- `TestCachedEvaluator_RefreshError_PreservesCache`
- `TestCachedEvaluator_Close_Idempotent`
- `TestCachedEvaluator_InitialPermissions_SeedsCache`
- `TestCachedEvaluator_Refresh_RequestShape`
- `TestCan_IAMResource_LiveCall_Granted`
- `TestCan_IAMResource_LiveCall_Denied`
- `TestCan_IAMResource_NilCtx_UsesBackground`
- `TestCan_IAMResource_EmptyArn_FallsThroughToCache`
- `TestCan_IAMResource_ExpectedMemberMismatch_ShortCircuits`
- `TestCan_IAMResource_PointerNil_TreatedAsPlainResource`

## Checklist

- [x] My code follows the project's coding style and conventions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I agree my contribution may be redistributed under either the [Apache 2.0](../LICENSE-APACHE) or [MIT](../LICENSE-MIT) license (project is dual-licensed; see [License of Contributions](../CONTRIBUTING.md#license-of-contributions))

## Additional Context

The other contributors to this project agree to the inbound rules for
all contributions made so far and provide their consent by approving
this PR.
