### PR TITLE
feat(chrono): DynamoDB + S3 LeaderElector backends

### DIFF
--- a/chrono/dynamolock/README.md
+++ b/chrono/dynamolock/README.md
@@ -1,0 +1,49 @@
+# dynamolock
+
+A `chrono.LeaderElector` backed by a single DynamoDB item. Ownership is
+coordinated by conditional `PutItem` writes: every renewal tick submits
+one write that succeeds only if the item is absent, already belongs to
+this owner, or has an expired lease. DynamoDB conditional writes are
+strongly consistent on a single item, so exactly one contender wins any
+contested transition.
+
+## Quick start
+
+```go
+import (
+    "github.com/aws/aws-sdk-go-v2/service/dynamodb"
+    "oss.nandlabs.io/golly-aws/chrono/dynamolock"
+    "oss.nandlabs.io/golly/chrono"
+)
+
+client := dynamodb.NewFromConfig(cfg)
+elector := dynamolock.New(client, dynamolock.Options{
+    Table: "chrono-locks",
+    Key:   "scheduler",
+    Owner: hostnamePidRandom(),
+    Lease: 15 * time.Second,
+})
+_ = elector.Start(ctx)
+defer elector.Resign(context.Background())
+
+sched := chrono.NewScheduler(chrono.WithLeaderElector(elector))
+```
+
+`IsLeader` reads a local atomic — safe to call in hot paths.
+
+## Table schema
+
+Create the table with a single partition key. Enable TTL on
+`lease_until` so DynamoDB eventually cleans up items no live contender
+is renewing.
+
+| Field         | Type                     | Notes                                  |
+| ------------- | ------------------------ | -------------------------------------- |
+| `lock_id`     | String (partition key)   | Value equals `Options.Key`.            |
+| `owner`       | String                   | Current holder's identity.             |
+| `lease_until` | Number (unix seconds)    | Enable **DynamoDB TTL** on this attr.  |
+| `version`     | Number                   | Monotonic; useful for diagnostics.     |
+
+**Clock skew:** the lease is an absolute wall-clock deadline, so
+instance clocks SHOULD stay within `Lease/2` of one another (NTP/chrony
+with the default sync interval is sufficient).

--- a/chrono/dynamolock/doc.go
+++ b/chrono/dynamolock/doc.go
@@ -1,0 +1,21 @@
+// Package dynamolock provides a chrono.LeaderElector backed by a single
+// DynamoDB item. Leadership is coordinated by conditional PutItem calls:
+// the elector claims/renews the lock only when either no live lease
+// exists (attribute_not_exists OR lease_until < now) or the item already
+// belongs to this owner. DynamoDB conditional writes are strongly
+// consistent, so at most one contender can commit a given transition.
+//
+// The elector runs a background renewal goroutine at Lease/2 cadence.
+// The persisted item carries {owner, lease_until, version}; lease_until
+// is stored as a Unix seconds number so it doubles as a DynamoDB TTL
+// attribute — enabling TTL on the table lets DynamoDB eventually garbage
+// collect stale items no live contender is renewing.
+//
+// The public IsLeader call performs no I/O — it reads a local atomic
+// updated by the renewal loop — so it is safe from hot paths (e.g.
+// per-tick from the scheduler).
+//
+// Clock skew: because the lock is expressed as an absolute wall-clock
+// deadline (lease_until), instances SHOULD keep clock skew below Lease/2
+// for correctness. NTP/chrony with a modest sync interval is sufficient.
+package dynamolock

--- a/chrono/dynamolock/dynamolock.go
+++ b/chrono/dynamolock/dynamolock.go
@@ -1,0 +1,300 @@
+package dynamolock
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+// Options configures a DynamoDB-backed leader elector.
+type Options struct {
+	// Table is the DynamoDB table that holds lock items. The table
+	// MUST have a single partition key named "lock_id" (type S). See
+	// README.md for the recommended schema and TTL setup.
+	Table string
+	// Key is the partition-key value that identifies THIS lock. All
+	// contenders for the same leadership role MUST agree on Table + Key.
+	Key string
+	// Owner is the identity of THIS instance. It should be globally
+	// unique across contenders (hostname+pid+random is a good default).
+	Owner string
+	// Lease is the renewal cadence. The elector attempts renewal every
+	// Lease/2, and the persisted expiry is now + 3*Lease. Choose Lease
+	// larger than expected clock skew and GC pauses.
+	Lease time.Duration
+}
+
+// item column names — kept as constants so the schema is documented in
+// one place and easy to keep in sync with README.md.
+const (
+	attrLockID     = "lock_id"
+	attrOwner      = "owner"
+	attrLeaseUntil = "lease_until"
+	attrVersion    = "version"
+)
+
+// ddbBackend abstracts the DynamoDB operations the elector needs so
+// tests can substitute an in-memory fake with matching conditional
+// semantics.
+type ddbBackend interface {
+	put(ctx context.Context, in *dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error)
+	get(ctx context.Context, in *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error)
+	del(ctx context.Context, in *dynamodb.DeleteItemInput) (*dynamodb.DeleteItemOutput, error)
+}
+
+// Elector implements chrono.LeaderElector on top of a single DynamoDB
+// item guarded by conditional writes.
+type Elector struct {
+	be   ddbBackend
+	opts Options
+	now  func() time.Time
+
+	leader atomic.Bool
+	// heldVersion is the version we last wrote successfully. It's used
+	// only on the renewal goroutine and on Resign after the goroutine
+	// has exited, so no lock is required.
+	heldVersion int64
+
+	startOnce sync.Once
+	started   bool
+	cancel    context.CancelFunc
+	done      chan struct{}
+}
+
+// New constructs a DynamoDB-backed Elector using the provided client.
+// The elector does not own the client — the caller manages its
+// lifecycle.
+func New(client *dynamodb.Client, opts Options) *Elector {
+	return newWithBackend(&clientBackend{c: client}, opts)
+}
+
+// newWithBackend is the internal constructor used by both New and tests.
+func newWithBackend(be ddbBackend, opts Options) *Elector {
+	return &Elector{
+		be:   be,
+		opts: opts,
+		now:  time.Now,
+	}
+}
+
+// Start validates configuration and launches the background renewal
+// goroutine. Idempotent — repeated calls are no-ops. Start performs one
+// synchronous tick before returning so callers who wait briefly can
+// observe leadership without racing the ticker.
+func (e *Elector) Start(ctx context.Context) error {
+	if err := e.validate(); err != nil {
+		return err
+	}
+	e.startOnce.Do(func() {
+		loopCtx, cancel := context.WithCancel(context.Background())
+		e.cancel = cancel
+		e.done = make(chan struct{})
+		e.started = true
+		_ = e.tick(ctx)
+		go e.run(loopCtx)
+	})
+	return nil
+}
+
+// IsLeader reads the atomic leadership flag maintained by the renewal
+// loop. It does NOT perform I/O and is safe from hot paths.
+func (e *Elector) IsLeader(_ context.Context) bool { return e.leader.Load() }
+
+// Resign stops the renewal loop and, if this instance currently owns
+// the lock, deletes the item with a conditional expression so a
+// successor that has already stolen the lease is not clobbered.
+func (e *Elector) Resign(ctx context.Context) error {
+	if !e.started {
+		return nil
+	}
+	if e.cancel != nil {
+		e.cancel()
+	}
+	if e.done != nil {
+		<-e.done
+	}
+	if !e.leader.Load() {
+		return nil
+	}
+	_, err := e.be.del(ctx, &dynamodb.DeleteItemInput{
+		TableName: aws.String(e.opts.Table),
+		Key: map[string]ddbtypes.AttributeValue{
+			attrLockID: &ddbtypes.AttributeValueMemberS{Value: e.opts.Key},
+		},
+		ConditionExpression: aws.String("#o = :us"),
+		ExpressionAttributeNames: map[string]string{
+			"#o": attrOwner,
+		},
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+			":us": &ddbtypes.AttributeValueMemberS{Value: e.opts.Owner},
+		},
+	})
+	e.leader.Store(false)
+	e.heldVersion = 0
+	if isConditionalCheckFailed(err) {
+		// Someone else already stole the lease — resign is a no-op.
+		return nil
+	}
+	return err
+}
+
+func (e *Elector) validate() error {
+	if e.opts.Table == "" {
+		return errors.New("dynamolock: Table required")
+	}
+	if e.opts.Key == "" {
+		return errors.New("dynamolock: Key required")
+	}
+	if e.opts.Owner == "" {
+		return errors.New("dynamolock: Owner required")
+	}
+	if e.opts.Lease <= 0 {
+		return errors.New("dynamolock: Lease must be > 0")
+	}
+	return nil
+}
+
+func (e *Elector) run(ctx context.Context) {
+	defer close(e.done)
+	interval := e.opts.Lease / 2
+	if interval <= 0 {
+		interval = e.opts.Lease
+	}
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			_ = e.tick(ctx)
+		}
+	}
+}
+
+// tick runs one renewal attempt.
+//
+//  1. Try a conditional PutItem that only succeeds if the item does
+//     not exist, we already own it, or the current lease has expired.
+//  2. On ConditionalCheckFailedException, GetItem to inspect the
+//     current owner and lease; if a live foreign lease is present we
+//     mark ourselves not-leader.
+//  3. Transport failures do NOT flip leadership state — the persisted
+//     lease_until is the source of truth for other observers.
+func (e *Elector) tick(ctx context.Context) error {
+	now := e.now()
+	expiry := now.Add(3 * e.opts.Lease).Unix()
+	nowUnix := now.Unix()
+	newVersion := e.heldVersion + 1
+	if newVersion <= 0 {
+		newVersion = 1
+	}
+
+	put := &dynamodb.PutItemInput{
+		TableName: aws.String(e.opts.Table),
+		Item: map[string]ddbtypes.AttributeValue{
+			attrLockID:     &ddbtypes.AttributeValueMemberS{Value: e.opts.Key},
+			attrOwner:      &ddbtypes.AttributeValueMemberS{Value: e.opts.Owner},
+			attrLeaseUntil: &ddbtypes.AttributeValueMemberN{Value: strconv.FormatInt(expiry, 10)},
+			attrVersion:    &ddbtypes.AttributeValueMemberN{Value: strconv.FormatInt(newVersion, 10)},
+		},
+		ConditionExpression: aws.String("attribute_not_exists(#k) OR #o = :us OR #l < :now"),
+		ExpressionAttributeNames: map[string]string{
+			"#k": attrLockID,
+			"#o": attrOwner,
+			"#l": attrLeaseUntil,
+		},
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+			":us":  &ddbtypes.AttributeValueMemberS{Value: e.opts.Owner},
+			":now": &ddbtypes.AttributeValueMemberN{Value: strconv.FormatInt(nowUnix, 10)},
+		},
+	}
+
+	if _, err := e.be.put(ctx, put); err == nil {
+		e.heldVersion = newVersion
+		e.leader.Store(true)
+		return nil
+	} else if !isConditionalCheckFailed(err) {
+		// Transport-level failure: preserve prior atomic value.
+		return err
+	}
+
+	// Conditional check failed — inspect the current item to see if
+	// someone else holds a live lease.
+	out, err := e.be.get(ctx, &dynamodb.GetItemInput{
+		TableName:      aws.String(e.opts.Table),
+		ConsistentRead: aws.Bool(true),
+		Key: map[string]ddbtypes.AttributeValue{
+			attrLockID: &ddbtypes.AttributeValueMemberS{Value: e.opts.Key},
+		},
+	})
+	if err != nil {
+		return err
+	}
+	owner, leaseUntil, ok := parseItem(out.Item)
+	if !ok {
+		// Item vanished between the failed PUT and the GET — next tick
+		// will try the create path again.
+		e.leader.Store(false)
+		return nil
+	}
+	// Per the condition, the PUT can only have failed when neither
+	// the item was absent, nor was owner==us, nor was the lease
+	// expired. So a foreign owner MUST be holding a live lease. We
+	// still guard on the observed values to stay correct under a
+	// concurrent successor that stole and renewed during our GetItem.
+	if owner != e.opts.Owner || leaseUntil > nowUnix {
+		e.leader.Store(false)
+	}
+	return nil
+}
+
+// parseItem extracts owner and lease_until from a DynamoDB item. It
+// returns ok=false when the item is nil or missing required fields, so
+// corrupt items are treated as "no lease held".
+func parseItem(item map[string]ddbtypes.AttributeValue) (owner string, leaseUntil int64, ok bool) {
+	if item == nil {
+		return "", 0, false
+	}
+	oav, ok1 := item[attrOwner].(*ddbtypes.AttributeValueMemberS)
+	lav, ok2 := item[attrLeaseUntil].(*ddbtypes.AttributeValueMemberN)
+	if !ok1 || !ok2 {
+		return "", 0, false
+	}
+	lu, err := strconv.ParseInt(lav.Value, 10, 64)
+	if err != nil {
+		return "", 0, false
+	}
+	return oav.Value, lu, true
+}
+
+// isConditionalCheckFailed unwraps a DynamoDB error and reports whether
+// it is a ConditionalCheckFailedException.
+func isConditionalCheckFailed(err error) bool {
+	if err == nil {
+		return false
+	}
+	var cf *ddbtypes.ConditionalCheckFailedException
+	return errors.As(err, &cf)
+}
+
+// clientBackend is the production backend that dispatches directly to
+// the DynamoDB client.
+type clientBackend struct{ c *dynamodb.Client }
+
+func (b *clientBackend) put(ctx context.Context, in *dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error) {
+	return b.c.PutItem(ctx, in)
+}
+func (b *clientBackend) get(ctx context.Context, in *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+	return b.c.GetItem(ctx, in)
+}
+func (b *clientBackend) del(ctx context.Context, in *dynamodb.DeleteItemInput) (*dynamodb.DeleteItemOutput, error) {
+	return b.c.DeleteItem(ctx, in)
+}

--- a/chrono/dynamolock/dynamolock_emulator_test.go
+++ b/chrono/dynamolock/dynamolock_emulator_test.go
@@ -1,0 +1,95 @@
+package dynamolock
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+)
+
+// newTestClient dials either a local dynamodb-local at DYNAMODB_ENDPOINT
+// or the caller's default AWS environment. The test is skipped unless
+// DYNAMODB_TEST_TABLE is set (both real AWS and local emulator require
+// the table to be pre-created — the elector does not create it).
+func newTestClient(t *testing.T) (*dynamodb.Client, string) {
+	t.Helper()
+	table := os.Getenv("DYNAMODB_TEST_TABLE")
+	if table == "" {
+		t.Skip("DYNAMODB_TEST_TABLE not set; skipping DynamoDB smoke test")
+	}
+	ctx := context.Background()
+	opts := []func(*config.LoadOptions) error{}
+	if r := os.Getenv("AWS_REGION"); r != "" {
+		opts = append(opts, config.WithRegion(r))
+	} else {
+		opts = append(opts, config.WithRegion("us-east-1"))
+	}
+	cfg, err := config.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		t.Fatalf("config.LoadDefaultConfig: %v", err)
+	}
+	var clientOpts []func(*dynamodb.Options)
+	if ep := os.Getenv("DYNAMODB_ENDPOINT"); ep != "" {
+		clientOpts = append(clientOpts, func(o *dynamodb.Options) {
+			o.BaseEndpoint = aws.String(ep)
+		})
+	}
+	return dynamodb.NewFromConfig(cfg, clientOpts...), table
+}
+
+func uniqueKey(t *testing.T) string {
+	return fmt.Sprintf("%s-%d", t.Name(), time.Now().UnixNano())
+}
+
+func TestSmoke_ClaimAndRenew(t *testing.T) {
+	client, table := newTestClient(t)
+	ctx := context.Background()
+
+	opts := Options{
+		Table: table,
+		Key:   uniqueKey(t),
+		Owner: "instance-a",
+		Lease: 500 * time.Millisecond,
+	}
+	e := New(client, opts)
+	if err := e.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	time.Sleep(750 * time.Millisecond)
+	if !e.IsLeader(ctx) {
+		t.Fatalf("expected leader after smoke tick")
+	}
+	if err := e.Resign(ctx); err != nil {
+		t.Fatalf("Resign: %v", err)
+	}
+}
+
+func TestSmoke_SecondInstanceLoses(t *testing.T) {
+	client, table := newTestClient(t)
+	ctx := context.Background()
+	key := uniqueKey(t)
+
+	a := New(client, Options{Table: table, Key: key, Owner: "a", Lease: 500 * time.Millisecond})
+	b := New(client, Options{Table: table, Key: key, Owner: "b", Lease: 500 * time.Millisecond})
+
+	if err := a.Start(ctx); err != nil {
+		t.Fatalf("a.Start: %v", err)
+	}
+	if err := b.Start(ctx); err != nil {
+		t.Fatalf("b.Start: %v", err)
+	}
+	time.Sleep(300 * time.Millisecond)
+	if !a.IsLeader(ctx) {
+		t.Fatalf("expected a to be leader")
+	}
+	if b.IsLeader(ctx) {
+		t.Fatalf("expected b to NOT be leader")
+	}
+	_ = a.Resign(ctx)
+	_ = b.Resign(ctx)
+}

--- a/chrono/dynamolock/dynamolock_test.go
+++ b/chrono/dynamolock/dynamolock_test.go
@@ -1,0 +1,414 @@
+package dynamolock
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+// fakeBackend is an in-memory substitute for the DynamoDB client with
+// matching conditional-write semantics on a single item keyed by
+// (Table, Key). All operations acquire the same mutex so the outcome
+// matches DynamoDB's strong-consistency guarantee for conditional writes
+// against a single item.
+type fakeBackend struct {
+	mu       sync.Mutex
+	item     map[string]ddbtypes.AttributeValue // nil == absent
+	calls    atomic.Int64
+	failNext atomic.Int64
+}
+
+var errInjected = errors.New("injected transport error")
+
+func newFakeBackend() *fakeBackend { return &fakeBackend{} }
+
+func (b *fakeBackend) put(ctx context.Context, in *dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error) {
+	b.calls.Add(1)
+	if n := b.failNext.Load(); n > 0 {
+		b.failNext.Add(-1)
+		return nil, errInjected
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if !b.evalCondition(in) {
+		return nil, &ddbtypes.ConditionalCheckFailedException{}
+	}
+	// Copy the item so callers can't mutate our storage.
+	b.item = cloneItem(in.Item)
+	return &dynamodb.PutItemOutput{}, nil
+}
+
+func (b *fakeBackend) get(ctx context.Context, in *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+	b.calls.Add(1)
+	if n := b.failNext.Load(); n > 0 {
+		b.failNext.Add(-1)
+		return nil, errInjected
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.item == nil {
+		return &dynamodb.GetItemOutput{}, nil
+	}
+	return &dynamodb.GetItemOutput{Item: cloneItem(b.item)}, nil
+}
+
+func (b *fakeBackend) del(ctx context.Context, in *dynamodb.DeleteItemInput) (*dynamodb.DeleteItemOutput, error) {
+	b.calls.Add(1)
+	if n := b.failNext.Load(); n > 0 {
+		b.failNext.Add(-1)
+		return nil, errInjected
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.item == nil {
+		// A delete of an absent item satisfies the "#o = :us" condition
+		// vacuously in our tests only if we're being asked WITH the
+		// condition; without a condition, it's a no-op. DynamoDB's real
+		// behavior differs — it treats attribute_exists as required for
+		// the condition to hold — so we mirror that here.
+		if in.ConditionExpression != nil {
+			return nil, &ddbtypes.ConditionalCheckFailedException{}
+		}
+		return &dynamodb.DeleteItemOutput{}, nil
+	}
+	if in.ConditionExpression != nil {
+		// The elector only issues "#o = :us" so we evaluate that.
+		wantOwner := extractS(in.ExpressionAttributeValues, ":us")
+		haveOwner := extractS(b.item, attrOwner)
+		if wantOwner != haveOwner {
+			return nil, &ddbtypes.ConditionalCheckFailedException{}
+		}
+	}
+	b.item = nil
+	return &dynamodb.DeleteItemOutput{}, nil
+}
+
+// evalCondition evaluates the elector's PutItem condition
+// "attribute_not_exists(#k) OR #o = :us OR #l < :now" against the fake's
+// current state. It's a minimal expression evaluator scoped to the
+// exact expression the elector emits.
+func (b *fakeBackend) evalCondition(in *dynamodb.PutItemInput) bool {
+	if in.ConditionExpression == nil {
+		return true
+	}
+	if b.item == nil {
+		// attribute_not_exists(#k)
+		return true
+	}
+	wantOwner := extractS(in.ExpressionAttributeValues, ":us")
+	haveOwner := extractS(b.item, attrOwner)
+	if wantOwner == haveOwner {
+		return true
+	}
+	nowStr := extractN(in.ExpressionAttributeValues, ":now")
+	leaseStr := extractN(b.item, attrLeaseUntil)
+	nowV, _ := strconv.ParseInt(nowStr, 10, 64)
+	leaseV, _ := strconv.ParseInt(leaseStr, 10, 64)
+	return leaseV < nowV
+}
+
+func extractS(m map[string]ddbtypes.AttributeValue, k string) string {
+	av, ok := m[k].(*ddbtypes.AttributeValueMemberS)
+	if !ok {
+		return ""
+	}
+	return av.Value
+}
+
+func extractN(m map[string]ddbtypes.AttributeValue, k string) string {
+	av, ok := m[k].(*ddbtypes.AttributeValueMemberN)
+	if !ok {
+		return ""
+	}
+	return av.Value
+}
+
+func cloneItem(m map[string]ddbtypes.AttributeValue) map[string]ddbtypes.AttributeValue {
+	out := make(map[string]ddbtypes.AttributeValue, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+// snapshot returns the fake's current item (nil if absent).
+func (b *fakeBackend) snapshot() map[string]ddbtypes.AttributeValue {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.item == nil {
+		return nil
+	}
+	return cloneItem(b.item)
+}
+
+// mockClock is a monotonic advancer for deterministic tick tests.
+type mockClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newMockClock(t time.Time) *mockClock { return &mockClock{now: t} }
+
+func (c *mockClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *mockClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+func newTestElector(be ddbBackend, owner string, clock *mockClock) *Elector {
+	e := newWithBackend(be, Options{
+		Table: "locks",
+		Key:   "sched",
+		Owner: owner,
+		Lease: 10 * time.Second,
+	})
+	e.now = clock.Now
+	return e
+}
+
+func ownerOf(item map[string]ddbtypes.AttributeValue) string {
+	return extractS(item, attrOwner)
+}
+
+func leaseOf(item map[string]ddbtypes.AttributeValue) int64 {
+	v, _ := strconv.ParseInt(extractN(item, attrLeaseUntil), 10, 64)
+	return v
+}
+
+func TestClaim_FirstAcquirer(t *testing.T) {
+	be := newFakeBackend()
+	clock := newMockClock(time.Unix(1_700_000_000, 0))
+	e := newTestElector(be, "instance-a", clock)
+
+	if err := e.tick(context.Background()); err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+	if !e.IsLeader(context.Background()) {
+		t.Fatalf("expected leader after first tick")
+	}
+	st := be.snapshot()
+	if ownerOf(st) != "instance-a" {
+		t.Fatalf("owner = %q, want instance-a", ownerOf(st))
+	}
+	if want := clock.Now().Add(30 * time.Second).Unix(); leaseOf(st) != want {
+		t.Fatalf("lease_until = %d, want %d", leaseOf(st), want)
+	}
+}
+
+func TestRenew_RetainsLeadershipAcrossLoops(t *testing.T) {
+	be := newFakeBackend()
+	clock := newMockClock(time.Unix(1_700_000_000, 0))
+	e := newTestElector(be, "instance-a", clock)
+
+	if err := e.tick(context.Background()); err != nil {
+		t.Fatalf("tick1: %v", err)
+	}
+	first := leaseOf(be.snapshot())
+
+	clock.Advance(4 * time.Second)
+	if err := e.tick(context.Background()); err != nil {
+		t.Fatalf("tick2: %v", err)
+	}
+	if !e.IsLeader(context.Background()) {
+		t.Fatalf("expected still leader after renewal")
+	}
+	second := leaseOf(be.snapshot())
+	if second <= first {
+		t.Fatalf("lease_until did not advance: first=%d second=%d", first, second)
+	}
+	if ownerOf(be.snapshot()) != "instance-a" {
+		t.Fatalf("owner drifted after renew")
+	}
+}
+
+func TestSteal_AfterLeaseExpiry(t *testing.T) {
+	be := newFakeBackend()
+	clock := newMockClock(time.Unix(1_700_000_000, 0))
+
+	incumbent := newTestElector(be, "instance-a", clock)
+	if err := incumbent.tick(context.Background()); err != nil {
+		t.Fatalf("incumbent tick: %v", err)
+	}
+
+	clock.Advance(31 * time.Second)
+
+	challenger := newTestElector(be, "instance-b", clock)
+	if err := challenger.tick(context.Background()); err != nil {
+		t.Fatalf("challenger tick: %v", err)
+	}
+	if !challenger.IsLeader(context.Background()) {
+		t.Fatalf("challenger should have stolen expired lease")
+	}
+	if ownerOf(be.snapshot()) != "instance-b" {
+		t.Fatalf("owner should be challenger after steal, got %q", ownerOf(be.snapshot()))
+	}
+}
+
+func TestSecondInstance_NotLeader_WhileFirstAlive(t *testing.T) {
+	be := newFakeBackend()
+	clock := newMockClock(time.Unix(1_700_000_000, 0))
+
+	a := newTestElector(be, "instance-a", clock)
+	b := newTestElector(be, "instance-b", clock)
+
+	if err := a.tick(context.Background()); err != nil {
+		t.Fatalf("a tick: %v", err)
+	}
+	clock.Advance(2 * time.Second)
+	if err := b.tick(context.Background()); err != nil {
+		t.Fatalf("b tick: %v", err)
+	}
+	if !a.IsLeader(context.Background()) {
+		t.Fatalf("a should still be leader")
+	}
+	if b.IsLeader(context.Background()) {
+		t.Fatalf("b should NOT be leader")
+	}
+	if ownerOf(be.snapshot()) != "instance-a" {
+		t.Fatalf("stored owner should remain instance-a")
+	}
+}
+
+func TestResign_ClearsRecord_WhenLeader(t *testing.T) {
+	be := newFakeBackend()
+	clock := newMockClock(time.Unix(1_700_000_000, 0))
+	e := newTestElector(be, "instance-a", clock)
+
+	if err := e.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !e.IsLeader(context.Background()) {
+		t.Fatalf("expected leader after Start")
+	}
+	if err := e.Resign(context.Background()); err != nil {
+		t.Fatalf("Resign: %v", err)
+	}
+	if e.IsLeader(context.Background()) {
+		t.Fatalf("expected NOT leader after Resign")
+	}
+	if be.snapshot() != nil {
+		t.Fatalf("expected item cleared, got %+v", be.snapshot())
+	}
+}
+
+func TestResign_NoOp_WhenNotLeader(t *testing.T) {
+	be := newFakeBackend()
+	clock := newMockClock(time.Unix(1_700_000_000, 0))
+
+	a := newTestElector(be, "instance-a", clock)
+	b := newTestElector(be, "instance-b", clock)
+
+	if err := a.Start(context.Background()); err != nil {
+		t.Fatalf("a Start: %v", err)
+	}
+	if err := b.Start(context.Background()); err != nil {
+		t.Fatalf("b Start: %v", err)
+	}
+	if !a.IsLeader(context.Background()) || b.IsLeader(context.Background()) {
+		t.Fatalf("expected a leader, b not — got a=%v b=%v", a.IsLeader(context.Background()), b.IsLeader(context.Background()))
+	}
+	if err := b.Resign(context.Background()); err != nil {
+		t.Fatalf("b Resign: %v", err)
+	}
+	if ownerOf(be.snapshot()) != "instance-a" {
+		t.Fatalf("b Resign clobbered a's ownership: %+v", be.snapshot())
+	}
+	if err := a.Resign(context.Background()); err != nil {
+		t.Fatalf("a Resign: %v", err)
+	}
+}
+
+func TestIsLeader_ReturnsAtomicallyFast(t *testing.T) {
+	be := &blockingBackend{ch: make(chan struct{})}
+	defer close(be.ch)
+	clock := newMockClock(time.Unix(1_700_000_000, 0))
+	e := newTestElector(be, "instance-a", clock)
+	e.leader.Store(true)
+
+	done := make(chan bool, 1)
+	start := time.Now()
+	go func() { done <- e.IsLeader(context.Background()) }()
+	select {
+	case v := <-done:
+		if !v {
+			t.Fatalf("IsLeader returned false, want true")
+		}
+		if time.Since(start) > 100*time.Millisecond {
+			t.Fatalf("IsLeader took too long — likely blocked on I/O")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("IsLeader did not return within 100ms — likely blocked on I/O")
+	}
+}
+
+// blockingBackend blocks every backend call until ch closes.
+type blockingBackend struct{ ch chan struct{} }
+
+func (b *blockingBackend) put(ctx context.Context, in *dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-b.ch:
+		return &dynamodb.PutItemOutput{}, nil
+	}
+}
+func (b *blockingBackend) get(ctx context.Context, in *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-b.ch:
+		return &dynamodb.GetItemOutput{}, nil
+	}
+}
+func (b *blockingBackend) del(ctx context.Context, in *dynamodb.DeleteItemInput) (*dynamodb.DeleteItemOutput, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-b.ch:
+		return &dynamodb.DeleteItemOutput{}, nil
+	}
+}
+
+func TestStart_IsIdempotent(t *testing.T) {
+	be := newFakeBackend()
+	clock := newMockClock(time.Unix(1_700_000_000, 0))
+	e := newTestElector(be, "instance-a", clock)
+	if err := e.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := e.Start(context.Background()); err != nil {
+		t.Fatalf("second Start: %v", err)
+	}
+	_ = e.Resign(context.Background())
+}
+
+func TestValidate_RejectsBadOptions(t *testing.T) {
+	be := newFakeBackend()
+	cases := map[string]Options{
+		"no table": {Key: "k", Owner: "o", Lease: time.Second},
+		"no key":   {Table: "t", Owner: "o", Lease: time.Second},
+		"no owner": {Table: "t", Key: "k", Lease: time.Second},
+		"no lease": {Table: "t", Key: "k", Owner: "o"},
+	}
+	for name, opts := range cases {
+		t.Run(name, func(t *testing.T) {
+			e := newWithBackend(be, opts)
+			if err := e.Start(context.Background()); err == nil {
+				t.Fatalf("expected validation error for %s", name)
+			}
+		})
+	}
+}

--- a/chrono/s3lock/README.md
+++ b/chrono/s3lock/README.md
@@ -1,0 +1,42 @@
+# s3lock
+
+A `chrono.LeaderElector` backed by a single S3 object. Ownership is
+coordinated by S3's write preconditions: `PutObject` with
+`If-None-Match: "*"` for the first claim, and `PutObject` with
+`If-Match: <ETag>` for renewals, steals, and resigns.
+
+## Quick start
+
+```go
+import (
+    "github.com/aws/aws-sdk-go-v2/service/s3"
+    "oss.nandlabs.io/golly-aws/chrono/s3lock"
+    "oss.nandlabs.io/golly/chrono"
+)
+
+client := s3.NewFromConfig(cfg)
+elector := s3lock.New(client, s3lock.Options{
+    Bucket: "my-locks",
+    Key:    "chrono/scheduler.lock",
+    Owner:  hostnamePidRandom(),
+    Lease:  15 * time.Second,
+})
+_ = elector.Start(ctx)
+defer elector.Resign(context.Background())
+
+sched := chrono.NewScheduler(chrono.WithLeaderElector(elector))
+```
+
+`IsLeader` reads a local atomic — safe to call in hot paths.
+
+## Requirements
+
+- **SDK version**: S3 conditional writes (`If-None-Match: "*"`) landed
+  in AWS on 20 Aug 2024 and require an SDK v2 release that surfaces
+  the `PutObjectInput.IfNoneMatch` field. This module's pinned
+  `github.com/aws/aws-sdk-go-v2/service/s3` version is post-Aug 2024
+  and does.
+- **Bucket must exist**. The elector does not create it.
+- **Clock skew**: the lease is an absolute wall-clock deadline, so
+  instance clocks SHOULD stay within `Lease/2` of one another
+  (NTP/chrony with the default sync interval is sufficient).

--- a/chrono/s3lock/doc.go
+++ b/chrono/s3lock/doc.go
@@ -1,0 +1,18 @@
+// Package s3lock provides a chrono.LeaderElector backed by a single
+// S3 object. Leadership is coordinated by S3's write preconditions:
+// PutObject with If-None-Match:"*" for the first claim, and PutObject
+// with If-Match:<etag> for renew, steal, and resign.
+//
+// S3 has provided strongly consistent read-after-write since December
+// 2020 and added conditional writes via If-None-Match in August 2024,
+// so exactly one contender wins any contested transition — the losers
+// receive HTTP 412 PreconditionFailed and observe the winner's state on
+// their next tick.
+//
+// The elector runs a background renewal goroutine at Lease/2 cadence.
+// The persisted body is a small JSON blob carrying {owner, lease_until}.
+// IsLeader reads a local atomic — no I/O — so it is safe from hot paths.
+//
+// Clock skew: lease_until is a wall-clock timestamp, so instances SHOULD
+// keep clock skew below Lease/2 for correctness.
+package s3lock

--- a/chrono/s3lock/s3lock.go
+++ b/chrono/s3lock/s3lock.go
@@ -1,0 +1,359 @@
+package s3lock
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+)
+
+// Options configures an S3-backed leader elector.
+type Options struct {
+	// Bucket is the S3 bucket that holds the lock object. The bucket
+	// must exist prior to Start; the elector does not create buckets.
+	Bucket string
+	// Key is the object path within the bucket (for example
+	// "locks/scheduler.lock"). All contenders for the same leadership
+	// role MUST agree on Bucket + Key.
+	Key string
+	// Owner uniquely identifies THIS instance. Hostname+pid+random is
+	// a reasonable default.
+	Owner string
+	// Lease is the renewal cadence. Renewal fires every Lease/2; the
+	// persisted expiry is now + 3*Lease. Choose Lease larger than
+	// expected clock skew and GC pauses.
+	Lease time.Duration
+}
+
+// lockDoc is the JSON body persisted in the lock object.
+type lockDoc struct {
+	Owner      string    `json:"owner"`
+	LeaseUntil time.Time `json:"lease_until"`
+}
+
+// s3Backend abstracts the S3 operations the elector needs so tests can
+// swap in an in-memory fake with matching precondition semantics.
+type s3Backend interface {
+	getObject(ctx context.Context, in *s3.GetObjectInput) (*s3.GetObjectOutput, error)
+	putObject(ctx context.Context, in *s3.PutObjectInput) (*s3.PutObjectOutput, error)
+	deleteObject(ctx context.Context, in *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error)
+}
+
+// errPreconditionFailed is the canonical sentinel returned by backend
+// methods when an IfMatch / IfNoneMatch condition fails.
+var errPreconditionFailed = errors.New("s3lock: precondition failed")
+
+// Elector implements chrono.LeaderElector on top of an S3 object
+// guarded by write preconditions.
+type Elector struct {
+	be   s3Backend
+	opts Options
+	now  func() time.Time
+
+	leader atomic.Bool
+	// heldETag is the ETag returned by the last successful PUT. It's
+	// used for renew (IfMatch) and Resign (IfMatch). Only accessed
+	// from the renewal goroutine and from Resign after the goroutine
+	// has exited, so no lock is needed.
+	heldETag string
+
+	startOnce sync.Once
+	started   bool
+	cancel    context.CancelFunc
+	done      chan struct{}
+}
+
+// New constructs an S3-backed Elector using the provided client. The
+// elector does not own the client — the caller manages its lifecycle.
+func New(client *s3.Client, opts Options) *Elector {
+	return newWithBackend(&clientBackend{c: client}, opts)
+}
+
+// newWithBackend is the internal constructor used by both New and tests.
+func newWithBackend(be s3Backend, opts Options) *Elector {
+	return &Elector{
+		be:   be,
+		opts: opts,
+		now:  time.Now,
+	}
+}
+
+// Start validates configuration and launches the background renewal
+// goroutine. Idempotent — repeated calls are no-ops. Start performs one
+// synchronous tick before returning so callers who wait briefly can
+// observe leadership without racing the ticker.
+func (e *Elector) Start(ctx context.Context) error {
+	if err := e.validate(); err != nil {
+		return err
+	}
+	e.startOnce.Do(func() {
+		loopCtx, cancel := context.WithCancel(context.Background())
+		e.cancel = cancel
+		e.done = make(chan struct{})
+		e.started = true
+		_ = e.tick(ctx)
+		go e.run(loopCtx)
+	})
+	return nil
+}
+
+// IsLeader reads the atomic leadership flag maintained by the renewal
+// loop. It does NOT perform I/O and is safe from hot paths.
+func (e *Elector) IsLeader(_ context.Context) bool { return e.leader.Load() }
+
+// Resign stops the renewal loop and, if this instance owns the lock,
+// deletes the object with an IfMatch precondition — that way a
+// successor which has already stolen the lease keeps its object.
+func (e *Elector) Resign(ctx context.Context) error {
+	if !e.started {
+		return nil
+	}
+	if e.cancel != nil {
+		e.cancel()
+	}
+	if e.done != nil {
+		<-e.done
+	}
+	if !e.leader.Load() || e.heldETag == "" {
+		return nil
+	}
+	_, err := e.be.deleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket:  aws.String(e.opts.Bucket),
+		Key:     aws.String(e.opts.Key),
+		IfMatch: aws.String(e.heldETag),
+	})
+	e.leader.Store(false)
+	e.heldETag = ""
+	if errors.Is(err, errPreconditionFailed) {
+		// Someone else already stole/wrote — that's fine on resign.
+		return nil
+	}
+	// A missing key on Resign is not an error either.
+	if isNoSuchKey(err) {
+		return nil
+	}
+	return err
+}
+
+func (e *Elector) validate() error {
+	if e.opts.Bucket == "" {
+		return errors.New("s3lock: Bucket required")
+	}
+	if e.opts.Key == "" {
+		return errors.New("s3lock: Key required")
+	}
+	if e.opts.Owner == "" {
+		return errors.New("s3lock: Owner required")
+	}
+	if e.opts.Lease <= 0 {
+		return errors.New("s3lock: Lease must be > 0")
+	}
+	return nil
+}
+
+func (e *Elector) run(ctx context.Context) {
+	defer close(e.done)
+	interval := e.opts.Lease / 2
+	if interval <= 0 {
+		interval = e.opts.Lease
+	}
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			_ = e.tick(ctx)
+		}
+	}
+}
+
+// tick runs one renewal attempt.
+//
+//  1. Try PutObject with If-None-Match:"*" to claim when the key is
+//     absent.
+//  2. On precondition failure, read the current object and inspect
+//     owner + lease_until.
+//  3. If we own it (renew) or it's expired (steal), PutObject with
+//     If-Match:<currentETag> — atomically overwriting the version we
+//     just read.
+//  4. Otherwise mark not-leader.
+func (e *Elector) tick(ctx context.Context) error {
+	now := e.now()
+	body, err := marshalDoc(lockDoc{Owner: e.opts.Owner, LeaseUntil: now.Add(3 * e.opts.Lease)})
+	if err != nil {
+		return err
+	}
+
+	// (1) First-claim path.
+	out, err := e.be.putObject(ctx, &s3.PutObjectInput{
+		Bucket:      aws.String(e.opts.Bucket),
+		Key:         aws.String(e.opts.Key),
+		Body:        bytes.NewReader(body),
+		IfNoneMatch: aws.String("*"),
+	})
+	if err == nil {
+		e.heldETag = derefETag(out.ETag)
+		e.leader.Store(true)
+		return nil
+	}
+	if !errors.Is(err, errPreconditionFailed) {
+		// Transport-level failure: preserve prior atomic value.
+		return err
+	}
+
+	// (2) Object exists — read to inspect owner + lease.
+	getOut, err := e.be.getObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(e.opts.Bucket),
+		Key:    aws.String(e.opts.Key),
+	})
+	if isNoSuchKey(err) {
+		// Rare race: someone deleted between our PUT attempt and the
+		// GET. Next tick will retry the create path.
+		e.leader.Store(false)
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	rawBody, curETag, err := readGet(getOut)
+	if err != nil {
+		return err
+	}
+	doc := parseDoc(rawBody)
+
+	// (3) Renew (we already hold it) or steal (expired).
+	if doc.Owner == e.opts.Owner || !doc.LeaseUntil.After(now) {
+		putOut, werr := e.be.putObject(ctx, &s3.PutObjectInput{
+			Bucket:  aws.String(e.opts.Bucket),
+			Key:     aws.String(e.opts.Key),
+			Body:    bytes.NewReader(body),
+			IfMatch: aws.String(curETag),
+		})
+		if werr != nil {
+			if errors.Is(werr, errPreconditionFailed) {
+				// Another instance beat us to the same write.
+				e.leader.Store(false)
+				return nil
+			}
+			return werr
+		}
+		e.heldETag = derefETag(putOut.ETag)
+		e.leader.Store(true)
+		return nil
+	}
+	// (4) Someone else holds a live lease.
+	e.leader.Store(false)
+	return nil
+}
+
+// marshalDoc serialises lockDoc to JSON.
+func marshalDoc(d lockDoc) ([]byte, error) {
+	b, err := json.Marshal(d)
+	if err != nil {
+		return nil, fmt.Errorf("s3lock: marshal lockDoc: %w", err)
+	}
+	return b, nil
+}
+
+// parseDoc decodes a stored body into a lockDoc. Corrupt bodies are
+// treated as an expired lease so the elector can steal them cleanly.
+func parseDoc(body []byte) lockDoc {
+	var d lockDoc
+	if err := json.Unmarshal(body, &d); err != nil {
+		return lockDoc{}
+	}
+	return d
+}
+
+// readGet consumes a GetObject response body and returns (body, etag).
+func readGet(out *s3.GetObjectOutput) ([]byte, string, error) {
+	defer func() { _ = out.Body.Close() }()
+	body, err := io.ReadAll(out.Body)
+	if err != nil {
+		return nil, "", err
+	}
+	return body, derefETag(out.ETag), nil
+}
+
+// derefETag returns the raw ETag string or "" for a nil pointer. S3
+// ETags are wrapped in double quotes; both IfMatch and IfNoneMatch
+// accept the quoted form so we don't strip them here.
+func derefETag(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}
+
+// isPreconditionFailedAPIError reports whether err is an S3
+// PreconditionFailed API error (HTTP 412). S3's SDK does not expose a
+// dedicated Go type for this response, so we detect it via the
+// smithy.APIError code.
+func isPreconditionFailedAPIError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	code := apiErr.ErrorCode()
+	return code == "PreconditionFailed"
+}
+
+// isNoSuchKey reports whether err indicates the S3 object is absent.
+// Some deployments (MinIO, older SDKs) surface this as an APIError code
+// rather than the strongly typed NoSuchKey struct, so we accept both.
+func isNoSuchKey(err error) bool {
+	if err == nil {
+		return false
+	}
+	var nsk *s3types.NoSuchKey
+	if errors.As(err, &nsk) {
+		return true
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		code := apiErr.ErrorCode()
+		return code == "NoSuchKey" || strings.EqualFold(code, "NotFound")
+	}
+	return false
+}
+
+// clientBackend is the production backend that dispatches directly to
+// the S3 client and normalises precondition-failed errors to the
+// canonical sentinel used by the tick logic.
+type clientBackend struct{ c *s3.Client }
+
+func (b *clientBackend) getObject(ctx context.Context, in *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+	return b.c.GetObject(ctx, in)
+}
+
+func (b *clientBackend) putObject(ctx context.Context, in *s3.PutObjectInput) (*s3.PutObjectOutput, error) {
+	out, err := b.c.PutObject(ctx, in)
+	if isPreconditionFailedAPIError(err) {
+		return nil, errPreconditionFailed
+	}
+	return out, err
+}
+
+func (b *clientBackend) deleteObject(ctx context.Context, in *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error) {
+	out, err := b.c.DeleteObject(ctx, in)
+	if isPreconditionFailedAPIError(err) {
+		return nil, errPreconditionFailed
+	}
+	return out, err
+}

--- a/chrono/s3lock/s3lock_emulator_test.go
+++ b/chrono/s3lock/s3lock_emulator_test.go
@@ -1,0 +1,97 @@
+package s3lock
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// newTestClient dials either MinIO / other S3-compatible service at
+// S3_ENDPOINT or the caller's default AWS environment. The test is
+// skipped unless S3_TEST_BUCKET is set (both real AWS and MinIO
+// require the bucket to be pre-created — the elector does not create
+// buckets).
+func newTestClient(t *testing.T) (*s3.Client, string) {
+	t.Helper()
+	bucket := os.Getenv("S3_TEST_BUCKET")
+	if bucket == "" {
+		t.Skip("S3_TEST_BUCKET not set; skipping S3 smoke test")
+	}
+	ctx := context.Background()
+	opts := []func(*config.LoadOptions) error{}
+	if r := os.Getenv("AWS_REGION"); r != "" {
+		opts = append(opts, config.WithRegion(r))
+	} else {
+		opts = append(opts, config.WithRegion("us-east-1"))
+	}
+	cfg, err := config.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		t.Fatalf("config.LoadDefaultConfig: %v", err)
+	}
+	var clientOpts []func(*s3.Options)
+	if ep := os.Getenv("S3_ENDPOINT"); ep != "" {
+		clientOpts = append(clientOpts, func(o *s3.Options) {
+			o.BaseEndpoint = aws.String(ep)
+			o.UsePathStyle = true
+		})
+	}
+	return s3.NewFromConfig(cfg, clientOpts...), bucket
+}
+
+func uniqueKey(t *testing.T) string {
+	return fmt.Sprintf("chrono-locks/%s-%d.json", t.Name(), time.Now().UnixNano())
+}
+
+func TestSmoke_ClaimAndRenew(t *testing.T) {
+	client, bucket := newTestClient(t)
+	ctx := context.Background()
+
+	opts := Options{
+		Bucket: bucket,
+		Key:    uniqueKey(t),
+		Owner:  "instance-a",
+		Lease:  500 * time.Millisecond,
+	}
+	e := New(client, opts)
+	if err := e.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	time.Sleep(750 * time.Millisecond)
+	if !e.IsLeader(ctx) {
+		t.Fatalf("expected leader after smoke tick")
+	}
+	if err := e.Resign(ctx); err != nil {
+		t.Fatalf("Resign: %v", err)
+	}
+}
+
+func TestSmoke_SecondInstanceLoses(t *testing.T) {
+	client, bucket := newTestClient(t)
+	ctx := context.Background()
+	key := uniqueKey(t)
+
+	a := New(client, Options{Bucket: bucket, Key: key, Owner: "a", Lease: 500 * time.Millisecond})
+	b := New(client, Options{Bucket: bucket, Key: key, Owner: "b", Lease: 500 * time.Millisecond})
+
+	if err := a.Start(ctx); err != nil {
+		t.Fatalf("a.Start: %v", err)
+	}
+	if err := b.Start(ctx); err != nil {
+		t.Fatalf("b.Start: %v", err)
+	}
+	time.Sleep(300 * time.Millisecond)
+	if !a.IsLeader(ctx) {
+		t.Fatalf("expected a to be leader")
+	}
+	if b.IsLeader(ctx) {
+		t.Fatalf("expected b to NOT be leader")
+	}
+	_ = a.Resign(ctx)
+	_ = b.Resign(ctx)
+}

--- a/chrono/s3lock/s3lock_test.go
+++ b/chrono/s3lock/s3lock_test.go
@@ -1,0 +1,390 @@
+package s3lock
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+// fakeBackend is an in-memory substitute for the S3 client with
+// matching If-Match / If-None-Match precondition semantics on a single
+// object slot. Every mutating operation advances the ETag; every
+// precondition check must match the current ETag exactly.
+type fakeBackend struct {
+	mu       sync.Mutex
+	exists   bool
+	body     []byte
+	etag     string
+	nextGen  int64
+	calls    atomic.Int64
+	failNext atomic.Int64
+}
+
+var errInjected = errors.New("injected transport error")
+
+func newFakeBackend() *fakeBackend { return &fakeBackend{nextGen: 100} }
+
+func (b *fakeBackend) advanceETag() {
+	b.nextGen++
+	b.etag = fmt.Sprintf("\"etag-%d\"", b.nextGen)
+}
+
+func (b *fakeBackend) getObject(ctx context.Context, in *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+	b.calls.Add(1)
+	if n := b.failNext.Load(); n > 0 {
+		b.failNext.Add(-1)
+		return nil, errInjected
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if !b.exists {
+		return nil, &s3types.NoSuchKey{}
+	}
+	buf := make([]byte, len(b.body))
+	copy(buf, b.body)
+	return &s3.GetObjectOutput{
+		Body: io.NopCloser(bytes.NewReader(buf)),
+		ETag: aws.String(b.etag),
+	}, nil
+}
+
+func (b *fakeBackend) putObject(ctx context.Context, in *s3.PutObjectInput) (*s3.PutObjectOutput, error) {
+	b.calls.Add(1)
+	if n := b.failNext.Load(); n > 0 {
+		b.failNext.Add(-1)
+		return nil, errInjected
+	}
+	body, err := io.ReadAll(in.Body)
+	if err != nil {
+		return nil, err
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	// If-None-Match: "*" requires the object to be absent.
+	if in.IfNoneMatch != nil && *in.IfNoneMatch == "*" {
+		if b.exists {
+			return nil, errPreconditionFailed
+		}
+	}
+	// If-Match: <etag> requires exact ETag match.
+	if in.IfMatch != nil {
+		if !b.exists || b.etag != *in.IfMatch {
+			return nil, errPreconditionFailed
+		}
+	}
+	b.exists = true
+	b.body = append([]byte(nil), body...)
+	b.advanceETag()
+	return &s3.PutObjectOutput{ETag: aws.String(b.etag)}, nil
+}
+
+func (b *fakeBackend) deleteObject(ctx context.Context, in *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error) {
+	b.calls.Add(1)
+	if n := b.failNext.Load(); n > 0 {
+		b.failNext.Add(-1)
+		return nil, errInjected
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if !b.exists {
+		// A delete of an absent key is a no-op — S3 returns 204.
+		return &s3.DeleteObjectOutput{}, nil
+	}
+	if in.IfMatch != nil && b.etag != *in.IfMatch {
+		return nil, errPreconditionFailed
+	}
+	b.exists = false
+	b.body = nil
+	b.advanceETag()
+	return &s3.DeleteObjectOutput{}, nil
+}
+
+// snapshot returns a copy of the fake's stored state.
+func (b *fakeBackend) snapshot() (exists bool, body []byte, etag string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if !b.exists {
+		return false, nil, b.etag
+	}
+	buf := make([]byte, len(b.body))
+	copy(buf, b.body)
+	return true, buf, b.etag
+}
+
+type mockClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newMockClock(t time.Time) *mockClock { return &mockClock{now: t} }
+
+func (c *mockClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *mockClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+func newTestElector(be s3Backend, owner string, clock *mockClock) *Elector {
+	e := newWithBackend(be, Options{
+		Bucket: "test-bucket",
+		Key:    "chrono/sched.lock",
+		Owner:  owner,
+		Lease:  10 * time.Second,
+	})
+	e.now = clock.Now
+	return e
+}
+
+func TestClaim_FirstAcquirer(t *testing.T) {
+	be := newFakeBackend()
+	clock := newMockClock(time.Unix(1_700_000_000, 0))
+	e := newTestElector(be, "instance-a", clock)
+
+	if err := e.tick(context.Background()); err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+	if !e.IsLeader(context.Background()) {
+		t.Fatalf("expected leader after first tick")
+	}
+	exists, body, _ := be.snapshot()
+	if !exists {
+		t.Fatalf("expected object created")
+	}
+	doc := parseDoc(body)
+	if doc.Owner != "instance-a" {
+		t.Fatalf("owner = %q, want instance-a", doc.Owner)
+	}
+	if want := clock.Now().Add(30 * time.Second); !doc.LeaseUntil.Equal(want) {
+		t.Fatalf("lease_until = %v, want %v", doc.LeaseUntil, want)
+	}
+}
+
+func TestRenew_RetainsLeadershipAcrossLoops(t *testing.T) {
+	be := newFakeBackend()
+	clock := newMockClock(time.Unix(1_700_000_000, 0))
+	e := newTestElector(be, "instance-a", clock)
+
+	if err := e.tick(context.Background()); err != nil {
+		t.Fatalf("tick1: %v", err)
+	}
+	_, body1, tag1 := be.snapshot()
+	first := parseDoc(body1).LeaseUntil
+
+	clock.Advance(4 * time.Second)
+	if err := e.tick(context.Background()); err != nil {
+		t.Fatalf("tick2: %v", err)
+	}
+	if !e.IsLeader(context.Background()) {
+		t.Fatalf("expected still leader after renewal")
+	}
+	_, body2, tag2 := be.snapshot()
+	second := parseDoc(body2).LeaseUntil
+	if !second.After(first) {
+		t.Fatalf("lease_until did not advance: first=%v second=%v", first, second)
+	}
+	if tag2 == tag1 {
+		t.Fatalf("ETag did not advance across renewals")
+	}
+	if parseDoc(body2).Owner != "instance-a" {
+		t.Fatalf("owner drifted after renew")
+	}
+}
+
+func TestSteal_AfterLeaseExpiry(t *testing.T) {
+	be := newFakeBackend()
+	clock := newMockClock(time.Unix(1_700_000_000, 0))
+
+	incumbent := newTestElector(be, "instance-a", clock)
+	if err := incumbent.tick(context.Background()); err != nil {
+		t.Fatalf("incumbent tick: %v", err)
+	}
+	clock.Advance(31 * time.Second)
+
+	challenger := newTestElector(be, "instance-b", clock)
+	if err := challenger.tick(context.Background()); err != nil {
+		t.Fatalf("challenger tick: %v", err)
+	}
+	if !challenger.IsLeader(context.Background()) {
+		t.Fatalf("challenger should have stolen expired lease")
+	}
+	_, body, _ := be.snapshot()
+	if parseDoc(body).Owner != "instance-b" {
+		t.Fatalf("owner should be challenger after steal")
+	}
+}
+
+func TestSecondInstance_NotLeader_WhileFirstAlive(t *testing.T) {
+	be := newFakeBackend()
+	clock := newMockClock(time.Unix(1_700_000_000, 0))
+
+	a := newTestElector(be, "instance-a", clock)
+	b := newTestElector(be, "instance-b", clock)
+
+	if err := a.tick(context.Background()); err != nil {
+		t.Fatalf("a tick: %v", err)
+	}
+	clock.Advance(2 * time.Second)
+	if err := b.tick(context.Background()); err != nil {
+		t.Fatalf("b tick: %v", err)
+	}
+	if !a.IsLeader(context.Background()) {
+		t.Fatalf("a should still be leader")
+	}
+	if b.IsLeader(context.Background()) {
+		t.Fatalf("b should NOT be leader")
+	}
+	_, body, _ := be.snapshot()
+	if parseDoc(body).Owner != "instance-a" {
+		t.Fatalf("stored owner should remain instance-a")
+	}
+}
+
+func TestResign_ClearsRecord_WhenLeader(t *testing.T) {
+	be := newFakeBackend()
+	clock := newMockClock(time.Unix(1_700_000_000, 0))
+	e := newTestElector(be, "instance-a", clock)
+
+	if err := e.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !e.IsLeader(context.Background()) {
+		t.Fatalf("expected leader after Start")
+	}
+	if err := e.Resign(context.Background()); err != nil {
+		t.Fatalf("Resign: %v", err)
+	}
+	if e.IsLeader(context.Background()) {
+		t.Fatalf("expected NOT leader after Resign")
+	}
+	exists, _, _ := be.snapshot()
+	if exists {
+		t.Fatalf("expected object cleared on Resign")
+	}
+}
+
+func TestResign_NoOp_WhenNotLeader(t *testing.T) {
+	be := newFakeBackend()
+	clock := newMockClock(time.Unix(1_700_000_000, 0))
+
+	a := newTestElector(be, "instance-a", clock)
+	b := newTestElector(be, "instance-b", clock)
+
+	if err := a.Start(context.Background()); err != nil {
+		t.Fatalf("a Start: %v", err)
+	}
+	if err := b.Start(context.Background()); err != nil {
+		t.Fatalf("b Start: %v", err)
+	}
+	if !a.IsLeader(context.Background()) || b.IsLeader(context.Background()) {
+		t.Fatalf("expected a leader, b not — got a=%v b=%v", a.IsLeader(context.Background()), b.IsLeader(context.Background()))
+	}
+	if err := b.Resign(context.Background()); err != nil {
+		t.Fatalf("b Resign: %v", err)
+	}
+	exists, body, _ := be.snapshot()
+	if !exists || parseDoc(body).Owner != "instance-a" {
+		t.Fatalf("b Resign clobbered a's ownership: exists=%v body=%q", exists, string(body))
+	}
+	if err := a.Resign(context.Background()); err != nil {
+		t.Fatalf("a Resign: %v", err)
+	}
+}
+
+func TestIsLeader_ReturnsAtomicallyFast(t *testing.T) {
+	be := &blockingBackend{ch: make(chan struct{})}
+	defer close(be.ch)
+	clock := newMockClock(time.Unix(1_700_000_000, 0))
+	e := newTestElector(be, "instance-a", clock)
+	e.leader.Store(true)
+
+	done := make(chan bool, 1)
+	start := time.Now()
+	go func() { done <- e.IsLeader(context.Background()) }()
+	select {
+	case v := <-done:
+		if !v {
+			t.Fatalf("IsLeader returned false, want true")
+		}
+		if time.Since(start) > 100*time.Millisecond {
+			t.Fatalf("IsLeader took too long — likely blocked on I/O")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("IsLeader did not return within 100ms — likely blocked on I/O")
+	}
+}
+
+// blockingBackend blocks every backend call until ch closes.
+type blockingBackend struct{ ch chan struct{} }
+
+func (b *blockingBackend) getObject(ctx context.Context, in *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-b.ch:
+		return &s3.GetObjectOutput{Body: io.NopCloser(bytes.NewReader(nil))}, nil
+	}
+}
+func (b *blockingBackend) putObject(ctx context.Context, in *s3.PutObjectInput) (*s3.PutObjectOutput, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-b.ch:
+		return &s3.PutObjectOutput{}, nil
+	}
+}
+func (b *blockingBackend) deleteObject(ctx context.Context, in *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-b.ch:
+		return &s3.DeleteObjectOutput{}, nil
+	}
+}
+
+func TestStart_IsIdempotent(t *testing.T) {
+	be := newFakeBackend()
+	clock := newMockClock(time.Unix(1_700_000_000, 0))
+	e := newTestElector(be, "instance-a", clock)
+	if err := e.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := e.Start(context.Background()); err != nil {
+		t.Fatalf("second Start: %v", err)
+	}
+	_ = e.Resign(context.Background())
+}
+
+func TestValidate_RejectsBadOptions(t *testing.T) {
+	be := newFakeBackend()
+	cases := map[string]Options{
+		"no bucket": {Key: "x", Owner: "y", Lease: time.Second},
+		"no key":    {Bucket: "b", Owner: "y", Lease: time.Second},
+		"no owner":  {Bucket: "b", Key: "x", Lease: time.Second},
+		"no lease":  {Bucket: "b", Key: "x", Owner: "y"},
+	}
+	for name, opts := range cases {
+		t.Run(name, func(t *testing.T) {
+			e := newWithBackend(be, opts)
+			if err := e.Start(context.Background()); err == nil {
+				t.Fatalf("expected validation error for %s", name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Adds two `chrono.LeaderElector` implementations under `chrono/` so multi-instance golly-chrono deployments running on AWS can elect a single scheduler leader without deploying additional coordination services. Both mirror the layout and style of the Firestore/GCS pair on golly-gcp.

- `chrono/dynamolock` — one DynamoDB item guarded by a conditional `PutItem` with `attribute_not_exists(lock_id) OR owner = us OR lease_until < now`. Strongly consistent on a single item. `lease_until` doubles as the DynamoDB TTL attribute so stale items are eventually reaped by the service.
- `chrono/s3lock` — one S3 object guarded by write preconditions. First claim uses `PutObject` with `If-None-Match: "*"`; renew/steal use `PutObject` with `If-Match: <ETag>`; Resign uses `DeleteObject` with `If-Match: <ETag>`. S3 conditional writes (`If-None-Match`) have been GA since 20 Aug 2024 and the pinned SDK version surfaces the `IfNoneMatch` field.

Both share the same shape: `Options { Table/Bucket, Key, Owner, Lease }`, `Start(ctx)`, `IsLeader(ctx) bool`, `Resign(ctx) error`. `IsLeader` reads a local atomic maintained by a background renewal goroutine that ticks at `Lease/2`, so it is safe to invoke from hot paths.

**Clock skew:** both leases are absolute wall-clock deadlines, so instance clocks SHOULD stay within `Lease/2` of one another (NTP/chrony with the default sync interval is sufficient).

### Related Issue

Closes #180

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- New package `chrono/dynamolock` with `Elector`, `Options`, `New`, and a `ddbBackend` seam for tests.
- New package `chrono/s3lock` with `Elector`, `Options`, `New`, and an `s3Backend` seam for tests.
- Fake-backend unit tests for each package covering: first-acquirer, renewal, steal after expiry, second-instance loses, Resign clears record when leader, Resign is no-op when not leader, `IsLeader` returns fast even with a blocked backend, `Start` is idempotent, and option validation.
- Opt-in smoke tests gated on `DYNAMODB_TEST_TABLE` / `S3_TEST_BUCKET` (with `DYNAMODB_ENDPOINT` / `S3_ENDPOINT` hooks for `dynamodb-local` / MinIO).
- `README.md` + `doc.go` quick-starts for each package documenting the schema/precondition requirements and the clock-skew guidance.
- Reuses the existing `service/dynamodb` and `service/s3` SDK deps; no `go.mod` change.

## Testing

- [x] I have added/updated unit tests for my changes
- [x] All existing tests pass (`go test ./...`)
- [x] I have tested this locally

### Test Output

\`\`\`
$ go build ./...
$ go vet ./...
$ go test -race -count=1 ./chrono/dynamolock/ ./chrono/s3lock/
ok  	oss.nandlabs.io/golly-aws/chrono/dynamolock	1.381s
ok  	oss.nandlabs.io/golly-aws/chrono/s3lock	1.526s
\`\`\`

## Checklist

- [x] My code follows the project's coding style and conventions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I agree my contribution may be redistributed under either the [Apache 2.0](../LICENSE-APACHE) or [MIT](../LICENSE-MIT) license (project is dual-licensed; see [License of Contributions](../CONTRIBUTING.md#license-of-contributions))

## Additional Context

The other contributors to this project agree to the inbound rules for all contributions made so far and provide their consent by approving this PR.